### PR TITLE
Update k8-configmap.yaml

### DIFF
--- a/kubernetes/k8-configmap.yaml
+++ b/kubernetes/k8-configmap.yaml
@@ -10,5 +10,5 @@ metadata:
     owner: szd2013
 data:
   AWS_DEFAULT_REGION: "us-east-1"
-  DB_HOST: "DB_HOST"
-  DB_NAME: "reciter"
+  DB_HOST: "<<DB_HOST>>"
+  DB_NAME: "<<DB_NAME>>"


### PR DESCRIPTION
Hi @rar4026 - These values should not be hard-coded. We need these data to be populated in Configmap for the Python script to execute. I've manually updated these values in ConfigMap for now.

Note that these data are in two different places where we have these values: Secrets and Configmap. Maybe we should just keep them in Secrets going forward. If this is the case, you can disregard this PR.
<img width="1375" alt="Screenshot 2023-05-09 at 3 29 41 PM" src="https://github.com/wcmc-its/ReCiterDB/assets/3651640/40def507-5373-4a71-a574-c7c568227318">
