### PR TITLE
Fix: NIH validation blocking table swap for 77+ days

### DIFF
--- a/setup/createDatabaseTableReciterDb.sql
+++ b/setup/createDatabaseTableReciterDb.sql
@@ -260,7 +260,7 @@ CREATE TABLE IF NOT EXISTS `analysis_nih` (
   `x_coord` float(5,4) DEFAULT NULL,
   `y_coord` float(5,4) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_pmid` (`pmid`) USING BTREE
+  UNIQUE KEY `idx_pmid` (`pmid`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `analysis_nih_cites` (

--- a/update/retrieveNIH.py
+++ b/update/retrieveNIH.py
@@ -207,6 +207,14 @@ def create_staging_tables(mysql_cursor, tables):
         mysql_cursor.execute(f"CREATE TABLE {staging_table} LIKE {table_name}")
         mysql_cursor.execute(f"ALTER TABLE {staging_table} MODIFY COLUMN id int(11) NOT NULL AUTO_INCREMENT")
         logger.info(f"Created staging table: {staging_table}")
+    # Add unique constraint on pmid for analysis_nih_new to prevent duplicates
+    try:
+        mysql_cursor.execute(
+            "ALTER TABLE analysis_nih_new ADD UNIQUE KEY uk_pmid (pmid)"
+        )
+        logger.info("Added UNIQUE constraint on pmid for analysis_nih_new")
+    except Exception as e:
+        logger.warning(f"Could not add UNIQUE constraint (may already exist): {e}")
 
 def atomic_table_swap(mysql_db, mysql_cursor, tables):
     """
@@ -274,6 +282,7 @@ def validate_data(mysql_cursor, staging_table, production_table, min_rows=100, m
     Validate staging table has sufficient data before swap.
     - Must have at least min_rows
     - Must have at least min_percentage of production table's row count
+    - Detects duplicate pmids in production (corruption) and uses unique count instead
     """
     mysql_cursor.execute(f"SELECT COUNT(*) as cnt FROM {staging_table}")
     staging_count = mysql_cursor.fetchone()['cnt']
@@ -281,8 +290,19 @@ def validate_data(mysql_cursor, staging_table, production_table, min_rows=100, m
     mysql_cursor.execute(f"SELECT COUNT(*) as cnt FROM {production_table}")
     production_count = mysql_cursor.fetchone()['cnt']
 
+    # Check for duplicates in production (corruption detection)
+    mysql_cursor.execute(f"SELECT COUNT(DISTINCT pmid) as cnt FROM {production_table}")
+    unique_production = mysql_cursor.fetchone()['cnt']
+
     logger.info(f"Validation: {staging_table} has {staging_count} rows, "
-                f"{production_table} has {production_count} rows")
+                f"{production_table} has {production_count} rows "
+                f"({unique_production} unique pmids)")
+
+    if production_count != unique_production:
+        logger.warning(f"CORRUPTION DETECTED: {production_table} has "
+                       f"{production_count - unique_production} duplicate rows. "
+                       f"Using unique count ({unique_production}) for validation.")
+        production_count = unique_production  # Use deduped count for comparison
 
     # Check minimum rows
     if staging_count < min_rows:
@@ -301,6 +321,21 @@ def validate_data(mysql_cursor, staging_table, production_table, min_rows=100, m
             return False
 
     logger.info(f"Validation PASSED for {staging_table}")
+    return True
+
+def check_production_integrity(mysql_cursor, table_name, key_column='pmid'):
+    """Check if production table has duplicate key values (corruption indicator)."""
+    mysql_cursor.execute(f"""
+        SELECT COUNT(*) as total_rows, COUNT(DISTINCT {key_column}) as unique_keys
+        FROM {table_name}
+    """)
+    result = mysql_cursor.fetchone()
+    total = result['total_rows']
+    unique = result['unique_keys']
+    if total != unique:
+        logger.warning(f"INTEGRITY CHECK: {table_name} has {total} rows but only "
+                       f"{unique} unique {key_column} values ({total - unique} duplicates)")
+        return False
     return True
 
 #########


### PR DESCRIPTION
## Summary

- **Root cause**: On Dec 18, 2025, `analysis_nih` was loaded with ~527K rows (2x the correct ~263K) due to no UNIQUE constraint on `pmid`. Every nightly run since has retrieved the correct ~267K rows, but validation rejects the swap (267K/527K = 50.7%, below the 80% threshold).
- `validate_data()` now detects duplicate pmids in production and uses the **unique** count for the percentage comparison, allowing the swap to self-heal on the next run
- `create_staging_tables()` adds a UNIQUE constraint on `pmid` for `analysis_nih_new` to prevent future duplicate inserts
- Schema DDL updated: `analysis_nih.idx_pmid` changed from `KEY` to `UNIQUE KEY`

## Test plan

- [ ] Next nightly run (reciterdb cronjob at 04:15 UTC) should log `CORRUPTION DETECTED`, pass validation, and complete the atomic table swap
- [ ] Verify via `SELECT COUNT(*) as total, COUNT(DISTINCT pmid) as uniq FROM analysis_nih;` — total should equal uniq after swap
- [ ] Confirm `analysis_nih_cites` and `analysis_nih_cites_clin` tables are also refreshed (they swap atomically together)