### PR TITLE
fix(retrieveNIH): correct column inversion in analysis_nih_cites load

### DIFF
--- a/update/retrieveNIH.py
+++ b/update/retrieveNIH.py
@@ -138,22 +138,23 @@ def write_records_to_csv(records, csv_files):
             nih_writer.writerow(nih_record)
             nih_count += 1
 
-            citing_pmid = get_dict_value(record, "pmid")
+            queried_pmid = get_dict_value(record, "pmid")
 
-            # Write to analysis_nih_cites
+            # iCite "cited_by" = articles that cite queried_pmid; "references" = articles queried_pmid cites.
+            # CSV column order matches LOAD DATA columns: (cited_pmid, citing_pmid).
             if record.get("cited_by"):
-                for cited_by in record["cited_by"]:
-                    cites_writer.writerow([cited_by, citing_pmid])
+                for citing in record["cited_by"]:
+                    cites_writer.writerow([queried_pmid, citing])
                     cites_count += 1
             if record.get("references"):
-                for ref in record["references"]:
-                    cites_writer.writerow([ref, citing_pmid])
+                for cited in record["references"]:
+                    cites_writer.writerow([cited, queried_pmid])
                     cites_count += 1
 
             # Write to analysis_nih_cites_clin
             if record.get("cited_by_clin"):
-                for cited_by_clin in record["cited_by_clin"]:
-                    cites_clin_writer.writerow([cited_by_clin, citing_pmid])
+                for citing_clin in record["cited_by_clin"]:
+                    cites_clin_writer.writerow([queried_pmid, citing_clin])
                     cites_clin_count +=1
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- `retrieveNIH.py` was writing iCite `cited_by` rows with the (cited_pmid, citing_pmid) columns inverted. The LOAD DATA column order is `(cited_pmid, citing_pmid)`, but for cited_by entries the queried PMID is the article being **cited**, not the citing one — so the code stored each row swapped. The `references` loop was correctly oriented; `cited_by_clin` had the same inversion as `cited_by`.
- Rename the local `citing_pmid` to `queried_pmid` and reorder the CSV writes for `cited_by` and `cited_by_clin` so the column meanings match the schema and downstream queries.

## Observed impact (pre-fix)
- PMID 32432483: iCite `citation_count`=192, but `SELECT COUNT(*) FROM analysis_nih_cites WHERE cited_pmid = 32432483` returned 19 — only the rows sourced from other WCM PMIDs' `references` arrays surfaced. The 192 cited_by edges were stored with the cited/citing columns swapped, hiding them from this query.
- Downstream consumer `Scholars-Profile-System/lib/api/publication-detail.ts` uses `WHERE c.cited_pmid = ? JOIN ON a.pmid = c.citing_pmid` — i.e., the semantically correct meaning. That query path has been silently undercounting since the iCite ETL was introduced.

## Rollout
- No schema change. The nightly run atomically swaps `analysis_nih_cites` and `analysis_nih_cites_clin`, so production becomes consistent at the next successful run.
- No migration of historical data needed (full rewrite each night).

## Test plan
- [ ] After deploy, trigger / wait for nightly run
- [ ] `SELECT COUNT(*) FROM analysis_nih_cites WHERE cited_pmid = 32432483` returns ~192 (iCite cited_by) + WCM `references` references = should align with iCite `citation_count`
- [ ] `SELECT COUNT(*) FROM analysis_nih_cites WHERE citing_pmid = <a WCM PMID with known references>` returns count consistent with iCite `references` length for that PMID
- [ ] Scholars-Profile-System publication-detail page shows the expected citing list for a high-citation pub