### PR TITLE
fix(reporter): dedup projects by appl_id before grant_reporter_project reload

### DIFF
--- a/update/retrieveReporter.py
+++ b/update/retrieveReporter.py
@@ -374,10 +374,19 @@ def main():
     # fields back than maintain two name conventions.
     project_rows = []
     appl_ids = []
+    seen_appl_ids = set()
     for proj in fetch_projects(base_criteria={'org_names': [org_name]}):
         appl_id = proj.get('appl_id')
         if not appl_id:
             continue
+        # RePORTER returns a project under every fiscal year it was active, so
+        # the FY-partitioned fetch (used when the corpus exceeds the 9,999
+        # offset cap) yields the same appl_id in multiple pages. appl_id is
+        # grant_reporter_project's PRIMARY KEY, so dedup before the reload —
+        # mirrors the seen_pairs guard in the publications loop below.
+        if appl_id in seen_appl_ids:
+            continue
+        seen_appl_ids.add(appl_id)
         appl_ids.append(appl_id)
         org = (proj.get('organization') or {}).get('org_name')
         project_rows.append((


### PR DESCRIPTION
## Summary

Follow-up to #81. A full-corpus run of `retrieveReporter.py` (~15K WCM projects) aborts with:

```
pymysql.err.IntegrityError: (1062, "Duplicate entry '10454407' for key 'PRIMARY'")
```

`fetch_projects()` partitions the RePORTER search by fiscal year when the corpus exceeds the 9,999 offset cap. RePORTER returns a multi-year project under **every** fiscal year it was active, so the same `appl_id` comes back across multiple FY pages. `appl_id` is `grant_reporter_project`'s PRIMARY KEY — the unguarded `reload_table` INSERT hits a duplicate-key violation. And because `reload_table` does `TRUNCATE` (which auto-commits) then `INSERT`, a failed run leaves `grant_reporter_project` empty.

## Fix

Dedup the projects loop by `appl_id` before the reload — mirrors the `seen_pairs` guard the publications loop already uses.

## Notes

- Pre-existing bug: the projects loop never deduped; the publications loop always did. Surfaced on a full-corpus production run.
- A full-corpus re-run with this fix is in progress to confirm it repopulates `grant_reporter_project` cleanly.
- `dev` counterpart follows (per the repo's dual-branch convention).