### PR TITLE
fix(reporter): dedup projects by appl_id before grant_reporter_project reload [dev]

### DIFF
--- a/update/retrieveReporter.py
+++ b/update/retrieveReporter.py
@@ -374,10 +374,19 @@ def main():
     # fields back than maintain two name conventions.
     project_rows = []
     appl_ids = []
+    seen_appl_ids = set()
     for proj in fetch_projects(base_criteria={'org_names': [org_name]}):
         appl_id = proj.get('appl_id')
         if not appl_id:
             continue
+        # RePORTER returns a project under every fiscal year it was active, so
+        # the FY-partitioned fetch (used when the corpus exceeds the 9,999
+        # offset cap) yields the same appl_id in multiple pages. appl_id is
+        # grant_reporter_project's PRIMARY KEY, so dedup before the reload —
+        # mirrors the seen_pairs guard in the publications loop below.
+        if appl_id in seen_appl_ids:
+            continue
+        seen_appl_ids.add(appl_id)
         appl_ids.append(appl_id)
         org = (proj.get('organization') or {}).get('org_name')
         project_rows.append((


### PR DESCRIPTION
`dev`-branch counterpart of #83 (which targets `master`).

A full-corpus run of `retrieveReporter.py` aborts with `IntegrityError 1062: Duplicate entry … for key 'PRIMARY'` — RePORTER returns a multi-year project under every fiscal year it was active, so the FY-partitioned fetch yields the same `appl_id` (the `grant_reporter_project` PK) in multiple pages. The fix dedups the projects loop by `appl_id`, mirroring the publications loop's existing `seen_pairs` guard.

Clean cherry-pick of the #83 commit. See #83 for full detail.