### PR TITLE
fix(docker): add missing COPY for retrieveReporter.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHONUNBUFFERED=1
 
 # Copy additional Python scripts
 COPY update/retrieveNIH.py ./
+COPY update/retrieveReporter.py ./
 COPY update/retrieveAltmetric.py ./
 COPY update/retrieveArticles.py ./
 COPY update/updateReciterDB.py ./


### PR DESCRIPTION
## Problem

The nightly `reciterdb` CronJob has been failing since the first run on the new image (built 2026-05-18 from `093ed47`; first run 2026-05-19 04:15 UTC).

PR #81 added a `retrieveReporter` step — `run_all.py` was updated to call it and `update/retrieveReporter.py` was committed — but the `Dockerfile`'s explicit per-file `COPY` list was never updated. The built image therefore lacked the script:

```
STARTING SCRIPT: retrieveReporter
retrieveReporter: python3: can't open file '/usr/src/app/retrieveReporter.py': [Errno 2] No such file or directory
❌ SCRIPT FAILED: retrieveReporter (exit code 2)
Stopping pipeline due to script failure.
```

`retrieveReporter` is step 4 of 7, so the pipeline halted before the nightly indexing SP, `abstractImport`, and `conflictsImport`. With `restartPolicy: OnFailure` the container restart-looped — re-running the full ~95-min pipeline and crashing at the same step every cycle (4 restarts in 7h13m before the stuck job was deleted).

## Fix

Add the missing `COPY update/retrieveReporter.py ./` to the Dockerfile.

## Verification

- `update/retrieveReporter.py` is tracked at this path; the new line mirrors the existing per-file `COPY` entries.
- CodeBuild rebuilds the image on merge to `master`.

## Notes

- `dev` has the identical bug — a matching PR targets `dev`.
- The migrations `setup/alter_add_reporter_fields_v1.2.sql` / `alter_add_reporter_terms_v1.3.sql` must be applied to the production DB before the new image runs cleanly (the successful manual run on 2026-05-18 against the prod RDS host indicates they already are).