### PR TITLE
fix(docker): add missing COPY for retrieveReporter.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ ENV PYTHONUNBUFFERED=1
 
 # Copy additional Python scripts
 COPY update/retrieveNIH.py ./
+COPY update/retrieveReporter.py ./
 COPY update/retrieveAltmetric.py ./
 COPY update/retrieveArticles.py ./
 COPY update/updateReciterDB.py ./


### PR DESCRIPTION
## Problem

`dev` carries the same Dockerfile bug as `master` (see #85). PR #81 added a `retrieveReporter` step — `run_all.py` calls it and `update/retrieveReporter.py` is committed — but the `Dockerfile`'s explicit per-file `COPY` list was never updated, so any image built from `dev` lacks the script and crashes at pipeline step 4:

```
retrieveReporter: python3: can't open file '/usr/src/app/retrieveReporter.py': [Errno 2] No such file or directory
❌ SCRIPT FAILED: retrieveReporter (exit code 2)
```

This is what caused the production restart loop on the `master` image overnight on 2026-05-19.

## Fix

Add the missing `COPY update/retrieveReporter.py ./` to the Dockerfile — same one-line change as #85, applied to `dev` so future `dev` builds are not broken.

## Verification

- `update/retrieveReporter.py` is tracked at this path; the new line mirrors the existing per-file `COPY` entries.
- CodeBuild rebuilds the image on merge to `dev`.