### PR TITLE
fix(reporting_abstracts): repair cross-paper concatenation from old CSV/LOAD DATA path (#87)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,14 @@ update/*.log
 update/app.log
 update/retrieveNIH.log
 update/temp/
+retrieveNIH.log
+
+# One-shot audit / repair artifacts (contain prod abstract text; never commit)
+audit_abstracts.csv
+audit_abstracts_dump.txt
+invalid_pmids.txt
+invalid_pmids.sql
+reporting_abstracts_corrupt_backup_*.sql
 
 # Legacy ML models (unused)
 update/*.keras

--- a/setup/alter_add_uq_pmid_reporting_abstracts_v1.4.sql
+++ b/setup/alter_add_uq_pmid_reporting_abstracts_v1.4.sql
@@ -1,0 +1,84 @@
+-- =============================================================================
+-- Migration: UNIQUE KEY on reporting_abstracts.pmid (v1.4)
+-- =============================================================================
+-- Replaces the existing non-unique `idx_pmid` index on reporting_abstracts
+-- with a UNIQUE KEY so the parser-desync class of failure that corrupted
+-- ~3,100 rows historically (issue #87, pre-PR #78 CSV / LOAD DATA path) can
+-- no longer silently produce duplicate-pmid rows.
+--
+-- WHY THIS IS NEEDED:
+--   update/abstractImport.py's fetch_missing_pmids() uses
+--     LEFT JOIN reporting_abstracts a ON a.pmid = p.pmid WHERE a.pmid IS NULL
+--   so the import path *assumes* one-row-per-pmid. The schema never
+--   enforced it. This migration codifies the assumption, mirroring the
+--   analysis_nih fix from March (PR #71/#72 after the Dec 2025 duplicate
+--   loading incident).
+--
+-- PRECONDITION:
+--   reporting_abstracts must contain zero duplicate pmids. The
+--   information_schema-guarded block at the top aborts the migration with a
+--   readable error if duplicates remain (run update/repairAbstracts.py
+--   first; it warns when duplicates are present).
+--
+-- Safe to run on prod and dev. Idempotent (information_schema guard;
+-- re-runs are no-ops once the UNIQUE KEY exists). No AFTER clause; the
+-- ALTER converts the existing BTREE index in place.
+-- =============================================================================
+
+SET @db = DATABASE();
+
+-- -----------------------------------------------------------------------------
+-- Precondition: no duplicate pmids.
+-- -----------------------------------------------------------------------------
+
+SET @dup_count = (
+    SELECT COUNT(*) FROM (
+        SELECT pmid FROM reporting_abstracts
+        GROUP BY pmid HAVING COUNT(*) > 1
+    ) d
+);
+
+SET @sql = IF(
+    @dup_count > 0,
+    CONCAT(
+        'SELECT ',
+        '''Migration aborted: reporting_abstracts has ',
+        @dup_count,
+        ' duplicate pmid value(s). Run update/repairAbstracts.py and resolve ',
+        'duplicates before re-running this migration.'' AS error, ',
+        '1/0 AS force_error'
+    ),
+    'SELECT ''No duplicate pmids; precondition satisfied.'' AS status'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- reporting_abstracts.idx_pmid: KEY -> UNIQUE KEY
+-- -----------------------------------------------------------------------------
+
+SET @already_unique = (
+    SELECT COUNT(*) FROM information_schema.statistics
+    WHERE table_schema = @db
+      AND table_name = 'reporting_abstracts'
+      AND index_name = 'idx_pmid'
+      AND non_unique = 0
+);
+
+SET @sql = IF(
+    @already_unique > 0,
+    'SELECT ''reporting_abstracts.idx_pmid is already UNIQUE; no-op.''',
+    'ALTER TABLE reporting_abstracts
+       DROP INDEX idx_pmid,
+       ADD UNIQUE KEY idx_pmid (pmid) USING BTREE'
+);
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+
+SELECT table_name, index_name, non_unique, column_name, index_type
+FROM information_schema.statistics
+WHERE table_schema = DATABASE()
+  AND table_name = 'reporting_abstracts'
+  AND index_name = 'idx_pmid';

--- a/setup/alter_add_uq_pmid_reporting_abstracts_v1.4.sql
+++ b/setup/alter_add_uq_pmid_reporting_abstracts_v1.4.sql
@@ -29,6 +29,13 @@ SET @db = DATABASE();
 
 -- -----------------------------------------------------------------------------
 -- Precondition: no duplicate pmids.
+--
+-- If duplicates exist, the precondition synthesizes a SELECT against a
+-- non-existent table whose name encodes the duplicate count. The resulting
+-- "Table doesn't exist" error halts execution (SELECT-with-1/0 only emits
+-- a warning, which MariaDB ignored outside a stored program in v1 of this
+-- migration -- the cleanup was attempted, ALTER ran anyway, ALTER failed
+-- on the first duplicate pmid).
 -- -----------------------------------------------------------------------------
 
 SET @dup_count = (
@@ -41,12 +48,9 @@ SET @dup_count = (
 SET @sql = IF(
     @dup_count > 0,
     CONCAT(
-        'SELECT ',
-        '''Migration aborted: reporting_abstracts has ',
+        'SELECT 1 FROM `__migration_aborted_reporting_abstracts_has_',
         @dup_count,
-        ' duplicate pmid value(s). Run update/repairAbstracts.py and resolve ',
-        'duplicates before re-running this migration.'' AS error, ',
-        '1/0 AS force_error'
+        '_duplicate_pmids__run_update_repairAbstracts_py_first`'
     ),
     'SELECT ''No duplicate pmids; precondition satisfied.'' AS status'
 );

--- a/setup/createDatabaseTableReciterDb.sql
+++ b/setup/createDatabaseTableReciterDb.sql
@@ -804,7 +804,7 @@ CREATE TABLE IF NOT EXISTS `reporting_abstracts` (
   `abstract` blob DEFAULT NULL,
   `abstractVarchar` varchar(15000) DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_pmid` (`pmid`) USING BTREE
+  UNIQUE KEY `idx_pmid` (`pmid`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `reporting_ad_hoc_feature_generator_execution` (

--- a/update/auditAbstracts.py
+++ b/update/auditAbstracts.py
@@ -1,0 +1,318 @@
+"""
+auditAbstracts.py -- one-shot forensic audit of reporting_abstracts.
+
+Pulls rows where LENGTH(abstract) >= AUDIT_LENGTH_THRESHOLD, fetches the
+DynamoDB ground truth for each PMID via the same path abstractImport.py
+uses, and classifies each row:
+
+  CLEAN              DB matches Dynamo (long but legitimate abstract).
+  PREFIX_CORRUPTED   First ~150 chars of the Dynamo abstract appear near
+                     the start of the DB blob and DB is substantially
+                     longer than Dynamo -- the cross-paper concatenation
+                     pattern produced by the old CSV / LOAD DATA path.
+  DISJOINT           DB front does not match Dynamo front; needs manual
+                     review.
+  MISSING_IN_DYNAMO  DynamoDB has no PubMedArticle record for the PMID.
+  EMPTY_IN_DYNAMO    Record present but yields empty abstract.
+
+Outputs:
+  - audit_abstracts.csv     one row per PMID examined
+  - audit_abstracts_dump.txt full text dump of the top N corrupted rows
+  - per-verdict counters and worst-offender summary to stdout
+
+Read-only. Does not modify reporting_abstracts.
+
+Env:
+  DB_USERNAME, DB_PASSWORD, DB_HOST, DB_NAME
+  AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION
+  AUDIT_LENGTH_THRESHOLD (default 4000)
+  AUDIT_MAX_CANDIDATES   (default 1000)
+"""
+
+import concurrent.futures
+import csv
+import logging
+import os
+import sys
+import time
+
+import boto3
+import pymysql.cursors
+import pymysql.err
+
+
+DB_USERNAME = os.getenv("DB_USERNAME")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+DB_HOST = os.getenv("DB_HOST")
+DB_NAME = os.getenv("DB_NAME")
+
+LENGTH_THRESHOLD = int(os.getenv("AUDIT_LENGTH_THRESHOLD", "4000"))
+MAX_CANDIDATES = int(os.getenv("AUDIT_MAX_CANDIDATES", "1000"))
+
+CHUNK_SIZE = 100
+MAX_WORKERS = 5
+MAX_UNPROCESSED_RETRIES = 8
+
+OUTPUT_CSV = "audit_abstracts.csv"
+DUMP_FILE = "audit_abstracts_dump.txt"
+DUMP_TOP_N = 5
+
+# Compare on the first HEAD_SAMPLE chars of the Dynamo abstract; require
+# it to be found within the first HEAD_SEARCH_WINDOW chars of the DB blob.
+# Short enough to tolerate leading-character noise (the orphan `"` and
+# similar CSV artifacts), long enough to be specific.
+HEAD_SAMPLE = 150
+HEAD_SEARCH_WINDOW = 400
+# A DB blob this much longer than Dynamo is the concatenation signal.
+LENGTH_INFLATION_RATIO = 1.3
+# BLOB-cap rule: a row right at the column cap with a Dynamo abstract many
+# times smaller is the parser-desync fingerprint regardless of whether the
+# first 150 chars happen to match (PubMed sometimes updated section labels
+# between the original CSV load and now, which can defeat the head-string
+# match).
+BLOB_CAP_THRESHOLD = 60000
+BLOB_CAP_INFLATION_RATIO = 5
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+logging.getLogger("botocore").setLevel(logging.WARNING)
+logging.getLogger("boto3").setLevel(logging.WARNING)
+
+
+def connect_mysql():
+    try:
+        return pymysql.connect(
+            user=DB_USERNAME,
+            password=DB_PASSWORD,
+            database=DB_NAME,
+            host=DB_HOST,
+            autocommit=True,
+            charset="utf8mb4",
+            cursorclass=pymysql.cursors.DictCursor,
+        )
+    except pymysql.err.MySQLError as err:
+        logger.error(f"DB connection failed: {err}")
+        sys.exit(1)
+
+
+def fetch_candidates(conn, threshold, max_rows):
+    sql = """
+        SELECT pmid, LENGTH(abstract) AS db_len, abstract
+        FROM reporting_abstracts
+        WHERE LENGTH(abstract) >= %s
+        ORDER BY LENGTH(abstract) DESC
+        LIMIT %s
+    """
+    with conn.cursor() as cur:
+        cur.execute(sql, (threshold, max_rows))
+        rows = cur.fetchall()
+    for r in rows:
+        if isinstance(r["abstract"], (bytes, bytearray)):
+            r["abstract"] = r["abstract"].decode("utf-8", errors="replace")
+        r["abstract"] = r["abstract"].replace("\r\n", "\n")
+    return rows
+
+
+def get_abstract(item):
+    """Same extraction logic as update/abstractImport.py:99."""
+    medline_citation = item.get("pubmedarticle", {}).get("medlinecitation")
+    if not medline_citation:
+        return ""
+    article = medline_citation.get("article")
+    if not article:
+        return ""
+    publication_abstract = article.get("publicationAbstract")
+    if not publication_abstract:
+        return ""
+    abstract_texts = []
+    for abstract_part in publication_abstract.get("abstractTexts", []):
+        label = abstract_part.get("abstractTextLabel")
+        text = abstract_part.get("abstractText")
+        if text:
+            label_text = f"{label}: " if label else ""
+            abstract_texts.append(label_text + text)
+    return " ".join(abstract_texts) if abstract_texts else ""
+
+
+def fetch_abstracts_from_dynamo(pmids):
+    client = boto3.resource("dynamodb").meta.client
+
+    def fetch_chunk(chunk):
+        request_keys = [{"pmid": p} for p in chunk]
+        results = {}
+        present = set()
+        attempt = 0
+        while request_keys:
+            response = client.batch_get_item(
+                RequestItems={"PubMedArticle": {"Keys": request_keys}}
+            )
+            for item in response["Responses"].get("PubMedArticle", []):
+                pmid = item.get("pmid")
+                if pmid is not None:
+                    present.add(pmid)
+                    results[pmid] = get_abstract(item)
+            request_keys = (
+                response.get("UnprocessedKeys", {})
+                .get("PubMedArticle", {})
+                .get("Keys", [])
+            )
+            if request_keys:
+                attempt += 1
+                if attempt > MAX_UNPROCESSED_RETRIES:
+                    logger.warning(
+                        f"{len(request_keys)} keys still unprocessed after "
+                        f"{MAX_UNPROCESSED_RETRIES} retries; skipping remainder."
+                    )
+                    break
+                time.sleep(min(0.1 * (2 ** attempt), 5.0))
+        return results, present
+
+    chunks = [pmids[i:i + CHUNK_SIZE] for i in range(0, len(pmids), CHUNK_SIZE)]
+    all_results = {}
+    found = set()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as ex:
+        futures = [ex.submit(fetch_chunk, c) for c in chunks]
+        for f in concurrent.futures.as_completed(futures):
+            res, present = f.result()
+            all_results.update(res)
+            found.update(present)
+    return all_results, found
+
+
+def classify(db_abs, dyn_abs, dyn_present):
+    if not dyn_present:
+        return "MISSING_IN_DYNAMO"
+    if not dyn_abs:
+        return "EMPTY_IN_DYNAMO"
+
+    db_norm = db_abs.strip()
+    dyn_norm = dyn_abs.strip()
+    if db_norm == dyn_norm:
+        return "CLEAN"
+
+    db_len = len(db_norm)
+    dyn_len = len(dyn_norm)
+
+    # Allow tiny tail differences (trailing whitespace/punctuation, an
+    # extra character or two) without flagging as corruption.
+    if abs(db_len - dyn_len) <= 5 and db_norm[: min(db_len, dyn_len) - 5 if db_len > 5 else db_len].lstrip('"') == dyn_norm[: min(db_len, dyn_len) - 5 if db_len > 5 else dyn_len].lstrip('"'):
+        return "CLEAN"
+
+    head_sample = dyn_norm[:HEAD_SAMPLE]
+    if head_sample and head_sample in db_norm[:HEAD_SEARCH_WINDOW]:
+        if db_len > dyn_len * LENGTH_INFLATION_RATIO:
+            return "PREFIX_CORRUPTED"
+        return "CLEAN"
+
+    if db_len >= BLOB_CAP_THRESHOLD and db_len > dyn_len * BLOB_CAP_INFLATION_RATIO:
+        return "PREFIX_CORRUPTED"
+
+    return "DISJOINT"
+
+
+def safe_oneline(s, n):
+    return s[:n].replace("\n", " ").replace("\t", " ").replace("\r", " ")
+
+
+def main():
+    logger.info(
+        f"Audit: LENGTH(abstract) >= {LENGTH_THRESHOLD}; "
+        f"max candidates: {MAX_CANDIDATES}"
+    )
+    conn = connect_mysql()
+    try:
+        candidates = fetch_candidates(conn, LENGTH_THRESHOLD, MAX_CANDIDATES)
+    finally:
+        conn.close()
+
+    logger.info(f"Candidates from reporting_abstracts: {len(candidates)}")
+    if not candidates:
+        logger.info("Nothing above threshold; exiting.")
+        return
+
+    lens = sorted(c["db_len"] for c in candidates)
+    logger.info(
+        f"DB length distribution: min={lens[0]} "
+        f"p50={lens[len(lens) // 2]} p95={lens[int(len(lens) * 0.95)]} "
+        f"max={lens[-1]}"
+    )
+
+    pmids = [c["pmid"] for c in candidates]
+    dyn_abstracts, dyn_present = fetch_abstracts_from_dynamo(pmids)
+    logger.info(
+        f"DynamoDB returned records for {len(dyn_present)} / {len(pmids)} PMIDs"
+    )
+
+    rows = []
+    counters = {
+        "CLEAN": 0,
+        "PREFIX_CORRUPTED": 0,
+        "DISJOINT": 0,
+        "MISSING_IN_DYNAMO": 0,
+        "EMPTY_IN_DYNAMO": 0,
+    }
+    for c in candidates:
+        pmid = c["pmid"]
+        db_abs = c["abstract"]
+        present = pmid in dyn_present
+        dyn_abs = dyn_abstracts.get(pmid, "")
+        verdict = classify(db_abs, dyn_abs, present)
+        counters[verdict] += 1
+        rows.append({
+            "pmid": pmid,
+            "db_len": c["db_len"],
+            "dyn_len": len(dyn_abs) if present else "",
+            "verdict": verdict,
+            "db_head": safe_oneline(db_abs, 80),
+            "db_tail": safe_oneline(db_abs[-80:] if len(db_abs) >= 80 else db_abs, 80),
+            "dyn_head": safe_oneline(dyn_abs, 80) if present else "",
+        })
+
+    with open(OUTPUT_CSV, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+    logger.info(f"Per-row audit written to {OUTPUT_CSV}")
+
+    logger.info("Verdict counts:")
+    for k in ("CLEAN", "PREFIX_CORRUPTED", "DISJOINT",
+              "MISSING_IN_DYNAMO", "EMPTY_IN_DYNAMO"):
+        logger.info(f"  {k:18s} {counters[k]}")
+
+    suspect = [r for r in rows if r["verdict"] in ("PREFIX_CORRUPTED", "DISJOINT")]
+    suspect.sort(key=lambda r: r["db_len"], reverse=True)
+
+    if suspect:
+        with open(DUMP_FILE, "w", encoding="utf-8") as f:
+            for r in suspect[:DUMP_TOP_N]:
+                pmid = r["pmid"]
+                db_abs = next(c["abstract"] for c in candidates if c["pmid"] == pmid)
+                dyn_abs = dyn_abstracts.get(pmid, "")
+                f.write("=" * 80 + "\n")
+                f.write(
+                    f"pmid={pmid} verdict={r['verdict']} "
+                    f"db_len={r['db_len']} dyn_len={r['dyn_len']}\n"
+                )
+                f.write("--- DB (full) ---\n")
+                f.write(db_abs + "\n")
+                f.write("--- Dynamo (full) ---\n")
+                f.write(dyn_abs + "\n\n")
+        logger.info(f"Top {DUMP_TOP_N} suspects dumped to {DUMP_FILE}")
+
+        logger.info(f"Top {min(DUMP_TOP_N, len(suspect))} suspects (summary):")
+        for r in suspect[:DUMP_TOP_N]:
+            logger.info(
+                f"  pmid={r['pmid']:>9} verdict={r['verdict']:17s} "
+                f"db_len={r['db_len']:>6} dyn_len={r['dyn_len']}"
+            )
+            logger.info(f"    db_head  : {r['db_head']!r}")
+            logger.info(f"    db_tail  : {r['db_tail']!r}")
+            logger.info(f"    dyn_head : {r['dyn_head']!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/update/repairAbstracts.py
+++ b/update/repairAbstracts.py
@@ -97,15 +97,31 @@ def count_matching(cur, pmids, batch=5000):
     return total
 
 
+def writable_columns(cur, table="reporting_abstracts"):
+    """Return the list of non-generated columns (those that accept INSERT).
+    Prod has a STORED generated column abstract_len that cannot be assigned;
+    INSERT must enumerate the real columns explicitly."""
+    cur.execute(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = DATABASE() AND table_name = %s "
+        "  AND (extra IS NULL OR extra NOT LIKE '%%GENERATED%%') "
+        "ORDER BY ordinal_position",
+        (table,),
+    )
+    return [r["column_name"] for r in cur.fetchall()]
+
+
 def backup_rows(cur, pmids, backup_table, batch):
     cur.execute(f"CREATE TABLE `{backup_table}` LIKE reporting_abstracts")
+    cols = writable_columns(cur)
+    col_list = ", ".join(f"`{c}`" for c in cols)
     inserted = 0
     for i in range(0, len(pmids), batch):
         chunk = pmids[i:i + batch]
         placeholders = ",".join(["%s"] * len(chunk))
         cur.execute(
-            f"INSERT INTO `{backup_table}` "
-            f"SELECT * FROM reporting_abstracts WHERE pmid IN ({placeholders})",
+            f"INSERT INTO `{backup_table}` ({col_list}) "
+            f"SELECT {col_list} FROM reporting_abstracts WHERE pmid IN ({placeholders})",
             chunk,
         )
         inserted += cur.rowcount
@@ -153,9 +169,12 @@ def count_duplicate_extras(cur):
 def backup_duplicate_extras(cur, backup_table):
     """Insert into the backup table every duplicate row except the MIN(id)
     keeper for each pmid. Returns the number of rows backed up."""
+    cols = writable_columns(cur)
+    col_list = ", ".join(f"`{c}`" for c in cols)
+    select_list = ", ".join(f"ra.`{c}`" for c in cols)
     cur.execute(
-        f"INSERT INTO `{backup_table}` "
-        "SELECT ra.* FROM reporting_abstracts ra "
+        f"INSERT INTO `{backup_table}` ({col_list}) "
+        f"SELECT {select_list} FROM reporting_abstracts ra "
         "JOIN ("
         "  SELECT pmid, MIN(id) AS keep_id FROM reporting_abstracts "
         "  GROUP BY pmid HAVING COUNT(*) > 1"

--- a/update/repairAbstracts.py
+++ b/update/repairAbstracts.py
@@ -1,0 +1,339 @@
+"""
+repairAbstracts.py -- one-shot cleanup of reporting_abstracts rows flagged
+as corrupted by update/auditAbstracts.py.
+
+Reads audit_abstracts.csv (the audit output) and:
+  1. Backs up the affected rows to reporting_abstracts_corrupt_backup_<ts>.
+  2. Deletes the corrupted rows from reporting_abstracts in batches.
+  3. Dedupes any remaining pmids that have multiple rows by keeping the
+     row with MIN(id) and backing up the rest to the same backup table.
+     (Precondition for the v1.4 UNIQUE KEY migration.)
+  4. Verifies post-state row counts and confirms no duplicate pmids remain.
+
+After this script runs, the next nightly update/abstractImport.py will
+re-fetch the deleted PMIDs cleanly via the parameterized executemany
+path introduced in PR #78.
+
+Destructive. Requires --apply to perform the delete; without --apply it
+runs in dry-run mode (counts only, no writes).
+
+Env:
+  DB_USERNAME, DB_PASSWORD, DB_HOST, DB_NAME
+"""
+
+import argparse
+import csv
+import datetime
+import logging
+import os
+import re
+import sys
+
+import pymysql.cursors
+import pymysql.err
+
+
+INVALID_VERDICTS = {"PREFIX_CORRUPTED", "DISJOINT", "EMPTY_IN_DYNAMO"}
+DEFAULT_AUDIT_CSV = "audit_abstracts.csv"
+DEFAULT_BATCH_SIZE = 500
+
+# Identifier safety: the backup-table suffix is timestamp-derived, but
+# allow callers to override with --backup-table; whitelist the shape to
+# refuse anything that would require quoting.
+SAFE_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
+
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+def connect_mysql():
+    try:
+        return pymysql.connect(
+            user=os.getenv("DB_USERNAME"),
+            password=os.getenv("DB_PASSWORD"),
+            database=os.getenv("DB_NAME"),
+            host=os.getenv("DB_HOST"),
+            autocommit=True,
+            charset="utf8mb4",
+            cursorclass=pymysql.cursors.DictCursor,
+        )
+    except pymysql.err.MySQLError as err:
+        logger.error(f"DB connection failed: {err}")
+        sys.exit(1)
+
+
+def read_invalid_pmids(audit_csv):
+    if not os.path.exists(audit_csv):
+        logger.error(f"Audit CSV not found: {audit_csv}")
+        logger.error("Run update/auditAbstracts.py first.")
+        sys.exit(1)
+    with open(audit_csv) as f:
+        rows = list(csv.DictReader(f))
+    if not rows or "verdict" not in rows[0] or "pmid" not in rows[0]:
+        logger.error(f"{audit_csv} is missing required columns (pmid, verdict).")
+        sys.exit(1)
+    return sorted({
+        int(r["pmid"]) for r in rows if r["verdict"] in INVALID_VERDICTS
+    })
+
+
+def count_matching(cur, pmids, batch=5000):
+    """COUNT(*) of rows whose pmid is in `pmids`, batched to avoid
+    oversized IN-lists. Returns the sum across batches."""
+    total = 0
+    for i in range(0, len(pmids), batch):
+        chunk = pmids[i:i + batch]
+        placeholders = ",".join(["%s"] * len(chunk))
+        cur.execute(
+            f"SELECT COUNT(*) AS c FROM reporting_abstracts "
+            f"WHERE pmid IN ({placeholders})",
+            chunk,
+        )
+        total += cur.fetchone()["c"]
+    return total
+
+
+def backup_rows(cur, pmids, backup_table, batch):
+    cur.execute(f"CREATE TABLE `{backup_table}` LIKE reporting_abstracts")
+    inserted = 0
+    for i in range(0, len(pmids), batch):
+        chunk = pmids[i:i + batch]
+        placeholders = ",".join(["%s"] * len(chunk))
+        cur.execute(
+            f"INSERT INTO `{backup_table}` "
+            f"SELECT * FROM reporting_abstracts WHERE pmid IN ({placeholders})",
+            chunk,
+        )
+        inserted += cur.rowcount
+        if (i // batch) % 5 == 0:
+            logger.info(f"  ... backed up {inserted:,} rows")
+    return inserted
+
+
+def delete_rows(cur, pmids, batch):
+    deleted = 0
+    for i in range(0, len(pmids), batch):
+        chunk = pmids[i:i + batch]
+        placeholders = ",".join(["%s"] * len(chunk))
+        cur.execute(
+            f"DELETE FROM reporting_abstracts WHERE pmid IN ({placeholders})",
+            chunk,
+        )
+        deleted += cur.rowcount
+        if (i // batch) % 5 == 0:
+            logger.info(f"  ... deleted {deleted:,} rows")
+    return deleted
+
+
+def find_duplicate_pmids(cur, limit=10):
+    cur.execute(
+        "SELECT pmid, COUNT(*) AS c FROM reporting_abstracts "
+        "GROUP BY pmid HAVING c > 1 LIMIT %s",
+        (limit,),
+    )
+    return cur.fetchall()
+
+
+def count_duplicate_extras(cur):
+    """Returns (group_count, extra_row_count). extra_row_count is the number
+    of rows that would need to be deleted to leave one row per pmid."""
+    cur.execute(
+        "SELECT COUNT(*) AS groups, COALESCE(SUM(c - 1), 0) AS extras FROM ("
+        "  SELECT COUNT(*) AS c FROM reporting_abstracts GROUP BY pmid HAVING c > 1"
+        ") d"
+    )
+    r = cur.fetchone()
+    return r["groups"], r["extras"]
+
+
+def backup_duplicate_extras(cur, backup_table):
+    """Insert into the backup table every duplicate row except the MIN(id)
+    keeper for each pmid. Returns the number of rows backed up."""
+    cur.execute(
+        f"INSERT INTO `{backup_table}` "
+        "SELECT ra.* FROM reporting_abstracts ra "
+        "JOIN ("
+        "  SELECT pmid, MIN(id) AS keep_id FROM reporting_abstracts "
+        "  GROUP BY pmid HAVING COUNT(*) > 1"
+        ") k ON k.pmid = ra.pmid AND ra.id <> k.keep_id"
+    )
+    return cur.rowcount
+
+
+def delete_duplicate_extras(cur):
+    """Delete every duplicate row except the MIN(id) keeper for each pmid.
+    Returns the number of rows deleted."""
+    cur.execute(
+        "DELETE ra FROM reporting_abstracts ra "
+        "JOIN ("
+        "  SELECT pmid, MIN(id) AS keep_id FROM reporting_abstracts "
+        "  GROUP BY pmid HAVING COUNT(*) > 1"
+        ") k ON k.pmid = ra.pmid AND ra.id <> k.keep_id"
+    )
+    return cur.rowcount
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--audit-csv", default=DEFAULT_AUDIT_CSV,
+                        help=f"Audit CSV path (default {DEFAULT_AUDIT_CSV})")
+    parser.add_argument("--apply", action="store_true",
+                        help="Perform the delete. Without this flag, dry-run only.")
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE,
+                        help=f"PMIDs per statement (default {DEFAULT_BATCH_SIZE})")
+    parser.add_argument("--backup-table", default=None,
+                        help="Backup table name (default: reporting_abstracts_corrupt_backup_<ts>)")
+    args = parser.parse_args()
+
+    pmids = read_invalid_pmids(args.audit_csv)
+    logger.info(f"Read {len(pmids):,} invalid PMIDs from {args.audit_csv}")
+    if not pmids:
+        logger.info("Nothing to repair.")
+        return
+
+    backup_table = args.backup_table or (
+        f"reporting_abstracts_corrupt_backup_"
+        f"{datetime.datetime.now():%Y%m%d_%H%M%S}"
+    )
+    if not SAFE_IDENT.match(backup_table):
+        logger.error(f"Refusing unsafe backup-table identifier: {backup_table!r}")
+        sys.exit(1)
+
+    conn = connect_mysql()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) AS c FROM reporting_abstracts")
+            before_total = cur.fetchone()["c"]
+
+            matching = count_matching(cur, pmids)
+            logger.info(
+                f"reporting_abstracts: {before_total:,} rows total; "
+                f"{matching:,} rows match the invalid-PMID list."
+            )
+
+            if matching > len(pmids):
+                logger.info(
+                    f"Live matches ({matching:,}) > unique PMIDs ({len(pmids):,}): "
+                    f"{matching - len(pmids):,} of the audited PMIDs have multiple "
+                    "rows in the live table (all of which will be deleted by the IN clause)."
+                )
+            elif matching < len(pmids):
+                logger.warning(
+                    f"Live matches ({matching:,}) < unique PMIDs ({len(pmids):,}): "
+                    f"{len(pmids) - matching:,} audited PMIDs no longer present "
+                    "(already deleted or table changed). Proceeding with what is live."
+                )
+
+            dupe_groups, dupe_extras = count_duplicate_extras(cur)
+            logger.info(
+                f"Duplicate-pmid groups: {dupe_groups:,} "
+                f"({dupe_extras:,} extra rows would be deduped after the corruption delete)."
+            )
+
+            if not args.apply:
+                cur.execute(
+                    "SELECT pmid, LENGTH(abstract) AS db_len FROM reporting_abstracts "
+                    "WHERE LENGTH(abstract) >= 4000 ORDER BY LENGTH(abstract) DESC LIMIT 3"
+                )
+                samples = cur.fetchall()
+                logger.info("Sample of longest current rows (pre-repair):")
+                for s in samples:
+                    logger.info(f"  pmid={s['pmid']:>9} db_len={s['db_len']}")
+                logger.info(f"Would back up to: `{backup_table}`")
+                logger.info(
+                    f"Would delete {matching:,} corrupted rows + dedupe "
+                    f"{dupe_extras:,} duplicate-extras (keep MIN(id) per pmid)."
+                )
+                logger.info("DRY RUN -- no changes made. Re-run with --apply to perform the repair.")
+                return
+
+            logger.info(f"Creating backup table `{backup_table}` ...")
+            backed_up = backup_rows(cur, pmids, backup_table, args.batch_size)
+            logger.info(f"Backed up {backed_up:,} rows to `{backup_table}`.")
+            if backed_up != matching:
+                logger.error(
+                    f"Backup row count {backed_up:,} != expected {matching:,}. Aborting."
+                )
+                sys.exit(1)
+
+            logger.info("Deleting corrupted rows from reporting_abstracts ...")
+            deleted = delete_rows(cur, pmids, args.batch_size)
+
+            cur.execute("SELECT COUNT(*) AS c FROM reporting_abstracts")
+            after_total = cur.fetchone()["c"]
+            logger.info(
+                f"Deleted {deleted:,} rows; reporting_abstracts now has "
+                f"{after_total:,} rows (was {before_total:,})."
+            )
+            if before_total - after_total != deleted:
+                logger.error(
+                    f"Row-count delta mismatch: before-after={before_total - after_total}, "
+                    f"deleted={deleted}. Backup table `{backup_table}` is intact."
+                )
+                sys.exit(1)
+
+            cur.execute(
+                "SELECT COUNT(*) AS c FROM reporting_abstracts WHERE LENGTH(abstract) >= 4000"
+            )
+            long_remaining = cur.fetchone()["c"]
+            logger.info(
+                f"Rows with LENGTH(abstract) >= 4000 remaining: {long_remaining:,} "
+                "(should approximately equal the CLEAN count from the audit)."
+            )
+
+            cur.execute(
+                "SELECT COUNT(*) AS c FROM reporting_abstracts WHERE LENGTH(abstract) >= 60000"
+            )
+            cap_remaining = cur.fetchone()["c"]
+            logger.info(
+                f"Rows at/above 60K (BLOB-cap region) remaining: {cap_remaining:,} "
+                "(should be 0 if repair caught all corruption)."
+            )
+
+            dupe_groups_after, dupe_extras_after = count_duplicate_extras(cur)
+            if dupe_extras_after > 0:
+                logger.info(
+                    f"Phase 2: deduping {dupe_extras_after:,} extra rows across "
+                    f"{dupe_groups_after:,} pmid groups (keeping MIN(id) per pmid)..."
+                )
+                backed_up_dupes = backup_duplicate_extras(cur, backup_table)
+                logger.info(f"  ... backed up {backed_up_dupes:,} duplicate rows to `{backup_table}`.")
+                if backed_up_dupes != dupe_extras_after:
+                    logger.error(
+                        f"Dedup backup count {backed_up_dupes:,} != expected {dupe_extras_after:,}. "
+                        "Aborting before delete."
+                    )
+                    sys.exit(1)
+                deleted_dupes = delete_duplicate_extras(cur)
+                logger.info(f"  ... deleted {deleted_dupes:,} duplicate rows.")
+                if deleted_dupes != dupe_extras_after:
+                    logger.error(
+                        f"Dedup delete count {deleted_dupes:,} != expected {dupe_extras_after:,}. "
+                        f"Backup table `{backup_table}` is intact."
+                    )
+                    sys.exit(1)
+            else:
+                logger.info("Phase 2: no duplicates to dedupe.")
+
+            dupes = find_duplicate_pmids(cur)
+            if dupes:
+                logger.error(
+                    f"{len(dupes)} duplicate pmid(s) still present after dedup (sample): "
+                    f"{[(d['pmid'], d['c']) for d in dupes]}"
+                )
+                sys.exit(1)
+            else:
+                logger.info(
+                    "No duplicate pmids remain. Safe to apply "
+                    "setup/alter_add_uq_pmid_reporting_abstracts_v1.4.sql."
+                )
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Mirror of #88 against `master`. Identical commit; see #88 for full discussion and review notes.

## Summary

Fixes #87. Pre-PR-#78 `abstractImport.py` wrote rows with `csv.writer` (RFC-4180 doubled-quote escaping) and `LOAD DATA LOCAL INFILE` (backslash escaping). On rows whose abstract text contained `"`, MySQL's parser desynced and consumed multiple TSV rows into one field, producing rows containing concatenated text from several other papers.

PR #78 stopped new corruption but didn't repair existing rows — `fetch_missing_pmids()` uses `LEFT JOIN ... WHERE a.pmid IS NULL`, so any pmid with a corrupted row was permanently skipped.

## Audit findings (prod, 2026-05-20)

- 391,238 total rows; **3,124** confirmed corrupted (84% pegged at the 65,535-byte BLOB cap)
- **181** content-identical duplicate pairs from concurrent old-import runs
- **464** legitimately long abstracts (4K–32K) preserved by verification approach
- Issue #87's PMID 33548241: `db_len=65,535`, real abstract `dyn_len=2,349` ([PubMed](https://pubmed.ncbi.nlm.nih.gov/33548241/))

## Changes

| File | Purpose |
|---|---|
| `update/auditAbstracts.py` | Forensic audit vs DynamoDB ground truth |
| `update/repairAbstracts.py` | Destructive cleanup. `--apply` required; dry-run by default |
| `setup/alter_add_uq_pmid_reporting_abstracts_v1.4.sql` | `UNIQUE KEY` on `reporting_abstracts.pmid` (mirrors `analysis_nih` fix from #71) |
| `setup/createDatabaseTableReciterDb.sql` | `idx_pmid` is now `UNIQUE` for fresh installs |
| `.gitignore` | Excludes audit / repair artifacts at repo root |

## DBA runbook after merge

1. `python3 update/auditAbstracts.py`
2. `python3 update/repairAbstracts.py` (dry-run)
3. `python3 update/repairAbstracts.py --apply`
4. `mysql ... < setup/alter_add_uq_pmid_reporting_abstracts_v1.4.sql`
5. Next nightly `abstractImport.py` re-fetches the 3,110 unique deleted PMIDs

## Test plan

- [x] Audit script run end-to-end against prod (3,588 candidates classified)
- [x] PMID 33548241 ground truth confirmed via PubMed ([DOI](https://doi.org/10.1016/j.yjmcc.2021.01.004))
- [x] Repair dry-run against prod: counts match (3,124 + 181 = 3,305)
- [x] Migration SQL idempotent; precondition guard works
- [ ] `--apply` against prod (gated on review)
- [ ] v1.4 migration applied
- [ ] Next nightly cleanly backfills

## Refs

- Issue #87 — cross-paper concatenation in `reporting_abstracts`
- PR #88 — same change against `dev`
- PR #78 / #80 — May 16 fix that stopped new corruption
- PR #71 / #72 — March `analysis_nih` UNIQUE-key precedent