### PR TITLE
feat(etl): scan ArticleProvenance (DynamoDB) -> article_provenance table (#95)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ ENV PYTHONUNBUFFERED=1
 # Copy additional Python scripts
 COPY update/retrieveNIH.py ./
 COPY update/retrieveReporter.py ./
+COPY update/retrieveArticleProvenance.py ./
 COPY update/retrieveAltmetric.py ./
 COPY update/retrieveArticles.py ./
 COPY update/updateReciterDB.py ./

--- a/README.md
+++ b/README.md
@@ -69,12 +69,15 @@ CronJob (daily)
      ├─ 1. executeFeatureGenerator.py    Trigger ReCiter ML scoring API
      ├─ 2. retrieveArticles.py           Pull person/article data from S3 + DynamoDB
      ├─ 3. retrieveNIH.py                NIH iCite API → analysis_nih (atomic swap)
-     ├─ 4. run_nightly_indexing.sh        Run populateAnalysisSummaryTables_v2()
+     ├─ 4. retrieveReporter.py           NIH RePORTER grants → grant_reporter_* (reconcile)
+     ├─ 5. retrieveArticleProvenance.py  ArticleProvenance (DynamoDB) → article_provenance
+     │      └─ non-fatal: a failure here does not block nightly indexing
+     ├─ 6. run_nightly_indexing.sh        Run populateAnalysisSummaryTables_v2()
      │      ├─ Polls analysis_job_log every 3s for progress
      │      ├─ Auto-retries 3x with 60s backoff
      │      └─ Auto-restores from backup on failure
-     ├─ 5. abstractImport.py             PubMed abstracts from DynamoDB
-     └─ 6. conflictsImport.py            COI statements from DynamoDB
+     ├─ 7. abstractImport.py             PubMed abstracts from DynamoDB
+     └─ 8. conflictsImport.py            COI statements from DynamoDB
 ```
 
 **Key patterns:**
@@ -105,6 +108,8 @@ ReCiterDB/
 │   ├── run_nightly_indexing.sh                    # SP runner with monitoring/retry
 │   ├── retrieveArticles.py                        # S3 + DynamoDB article fetcher
 │   ├── retrieveNIH.py                             # NIH iCite fetcher (atomic swap)
+│   ├── retrieveReporter.py                        # NIH RePORTER grants fetcher (reconcile)
+│   ├── retrieveArticleProvenance.py               # ArticleProvenance (DynamoDB) → article_provenance
 │   ├── retrieveAltmetric.py                       # Altmetric API fetcher
 │   ├── updateReciterDB.py                         # Bulk loader (LOAD DATA LOCAL INFILE)
 │   ├── dataTransformer.py                         # ReCiter JSON → CSV
@@ -288,6 +293,8 @@ All defined in `setup/createEventsProceduresReciterDb.sql`.
 | `run_all.py` | EKS orchestrator: runs all pipeline steps in sequence with timeout enforcement, memory logging, and S3 log upload |
 | `retrieveArticles.py` | Fetches person and article data from S3 and DynamoDB in batches |
 | `retrieveNIH.py` | Fetches NIH iCite metrics in batches of 150; loads to staging table with validation and atomic swap |
+| `retrieveReporter.py` | Fetches NIH RePORTER grants/linkages and reconciles them into `grant_reporter_*` / `grant_provenance` |
+| `retrieveArticleProvenance.py` | Scans DynamoDB `ArticleProvenance` → `article_provenance` (pmid, personIdentifier) via staging + atomic swap; runs non-fatal |
 | `retrieveAltmetric.py` | Fetches Altmetric scores for articles published in the last 2 years |
 | `updateReciterDB.py` | Bulk data loader using `LOAD DATA LOCAL INFILE` with retry and reconnect logic |
 | `dataTransformer.py` | Transforms ReCiter JSON output to CSV format for all `person_*` tables |

--- a/setup/alter_add_article_provenance_v1.6.sql
+++ b/setup/alter_add_article_provenance_v1.6.sql
@@ -1,0 +1,56 @@
+-- =============================================================================
+-- Migration: Add article_provenance table (v1.6)
+-- =============================================================================
+-- Creates the article_provenance table on EXISTING databases (dev, prod). Fresh
+-- builds already get it from setup/createDatabaseTableReciterDb.sql (ReCiterDB#95).
+--
+-- WHAT IT IS:
+--   First-retrieval provenance per (article, person), loaded nightly by
+--   update/retrieveArticleProvenance.py from the ReCiter DynamoDB
+--   `ArticleProvenance` table. That source table has a COMPOSITE key
+--   uid (HASH, personIdentifier) + articleId (RANGE, PMID), so there is one item
+--   per person+article. This table mirrors that key exactly -- PRIMARY KEY
+--   (pmid, personIdentifier) -- rather than collapsing to one row per PMID.
+--
+--   Columns map from DynamoDB attributes:
+--     pmid               <- articleId (String PMID -> INT)
+--     personIdentifier   <- uid
+--     firstRetrievalDate <- frd  (epoch SECONDS, UTC -> DATETIME)
+--     retrievalStrategy  <- rs   (PM_UI_SEARCH, PM_AUTHOR, ...)
+--     source             <- src  (PM, CTSC, GS, MAN, MAN_FROM_PM, ...)
+--
+-- WHY THIS MIGRATION EXISTS:
+--   Publication Manager #737 displays "date a publication was first retrieved"
+--   in /curate and reads this table by PMID. The table must exist before the PM
+--   #737 branch is deployed against this database.
+--
+-- DURABILITY / ETL CONTRACT:
+--   Loaded via a staging table (article_provenance_new) + atomic RENAME swap by
+--   the nightly ETL, exactly like analysis_nih. It is NOT in
+--   update/updateReciterDB.py's truncate list and is not touched by any nightly
+--   stored procedure. A failure in the ETL step leaves production untouched and
+--   does not block the rest of run_all.py (the step runs as non-fatal).
+--
+-- Safe to run on prod and dev. CREATE TABLE IF NOT EXISTS is a no-op on re-run
+-- and additive only -- no existing table or row is modified.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `article_provenance` (
+  `pmid`               int(11)      NOT NULL,
+  `personIdentifier`   varchar(128) NOT NULL,
+  `firstRetrievalDate` datetime     DEFAULT NULL,
+  `retrievalStrategy`  varchar(64)  DEFAULT NULL,
+  `source`             varchar(32)  DEFAULT NULL,
+  PRIMARY KEY (`pmid`, `personIdentifier`),
+  KEY `idx_personIdentifier` (`personIdentifier`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+
+SELECT table_name, column_name, data_type, character_maximum_length, is_nullable, column_key
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'article_provenance'
+ORDER BY ordinal_position;

--- a/setup/createDatabaseTableReciterDb.sql
+++ b/setup/createDatabaseTableReciterDb.sql
@@ -492,6 +492,23 @@ CREATE TABLE IF NOT EXISTS `analysis_temp_output_table_cell` (
   KEY `personIdentifier` (`personIdentifier`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- article_provenance: first-retrieval provenance per (article, person), loaded
+-- nightly by update/retrieveArticleProvenance.py from the ReCiter DynamoDB
+-- `ArticleProvenance` table (composite key uid + articleId). Keyed on
+-- (pmid, personIdentifier) to mirror that source key exactly -- one row per
+-- person+article. firstRetrievalDate is `frd` (epoch seconds, UTC) converted to
+-- DATETIME. Loaded via staging->atomic-swap; NOT in any truncate list.
+-- Consumed by Publication Manager #737 ("date a publication was first retrieved").
+CREATE TABLE IF NOT EXISTS `article_provenance` (
+  `pmid`               int(11)      NOT NULL,
+  `personIdentifier`   varchar(128) NOT NULL,
+  `firstRetrievalDate` datetime     DEFAULT NULL,
+  `retrievalStrategy`  varchar(64)  DEFAULT NULL,
+  `source`             varchar(32)  DEFAULT NULL,
+  PRIMARY KEY (`pmid`, `personIdentifier`),
+  KEY `idx_personIdentifier` (`personIdentifier`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- ============================================================================
 -- Journal Tables
 -- ============================================================================

--- a/update/retrieveArticleProvenance.py
+++ b/update/retrieveArticleProvenance.py
@@ -1,0 +1,353 @@
+# retrieveArticleProvenance.py
+#
+# Nightly ETL step that scans the ReCiter DynamoDB `ArticleProvenance` table and
+# loads it into the reciterdb `article_provenance` table. Powers the Publication
+# Manager "date a publication was first retrieved" display in /curate
+# (wcmc-its/ReCiter-Publication-Manager#737); backend half of ReCiterDB#95.
+#
+# Source table (reciter.service.dynamo.ArticleProvenanceServiceImpl):
+#   - COMPOSITE key: `uid` (HASH, the personIdentifier/CWID) + `articleId` (RANGE,
+#     the PMID as a String). One item per (person, article) pair.
+#   - `frd` = first retrieval date, epoch SECONDS, written with if_not_exists so it
+#     is immutable once set (the first time that person retrieved that article).
+#   - `rs`  = first retrieval strategy (PM_UI_SEARCH, PM_AUTHOR, ...).
+#   - `src` = source (PM, CTSC, GS, MAN, MAN_FROM_PM, ...).
+#   - `ads` = String Set of all strategies seen (not loaded here).
+#
+# reciterdb target is keyed on (pmid, personIdentifier) -- it mirrors the DynamoDB
+# composite key exactly (one row per person+article), so no cross-person collapse
+# is performed. frd (epoch seconds, UTC) is converted to a DATETIME on load to
+# match the rest of reciterdb; PM formats it for display.
+#
+# Memory: rows are streamed into the staging table one scan page at a time
+# (INSERT IGNORE), so peak RSS is bounded to one page regardless of corpus size.
+# INSERT IGNORE also collapses any (pmid, personIdentifier) collision (e.g. a
+# case-variant uid under the utf8mb4_unicode_ci PK) rather than aborting the load.
+#
+# Atomicity: mirrors retrieveNIH.py -- load into a `article_provenance_new`
+# staging table, validate it against production, then RENAME-swap. A failure here
+# leaves production untouched. run_all.py runs this step as NON-FATAL so a hiccup
+# does not block the nightly indexing SP (PM reads this table directly; nothing
+# downstream depends on it).
+
+import os
+import sys
+import time
+import random
+import logging
+import faulthandler
+import signal
+from datetime import datetime, timezone
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
+import pymysql.cursors
+import pymysql.err
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler('retrieveArticleProvenance.log', mode='w'),
+        logging.StreamHandler(sys.stdout),
+    ],
+)
+logger = logging.getLogger(__name__)
+
+faulthandler.enable(file=sys.stderr, all_threads=True)
+faulthandler.register(signal.SIGUSR1, file=sys.stderr, all_threads=True)
+
+DYNAMO_TABLE = 'ArticleProvenance'
+TARGET_TABLE = 'article_provenance'
+STAGING_TABLE = 'article_provenance_new'
+BACKUP_TABLE = 'article_provenance_backup'
+SCAN_PAGE_SIZE = 1000
+
+# Validation floor: reject a partial/empty scan that would otherwise seed or
+# replace production with too little data (matches retrieveNIH's min_rows).
+MIN_STAGING_ROWS = 100
+# Warn if more than this fraction of scanned items are skipped (data-quality signal).
+SKIP_RATIO_WARN = 0.10
+
+# Plausible bounds for frd (epoch seconds). Anything outside is treated as corrupt
+# and stored NULL rather than a bogus DATETIME. Lower bound = 2000-01-01 UTC.
+MIN_EPOCH_SECONDS = 946684800
+
+# DDL kept in sync with setup/createDatabaseTableReciterDb.sql and
+# setup/alter_add_article_provenance_v1.6.sql. Created defensively so a fresh
+# environment that has not yet run the migration still works.
+CREATE_TARGET_SQL = f"""
+CREATE TABLE IF NOT EXISTS `{TARGET_TABLE}` (
+  `pmid`               int(11)      NOT NULL,
+  `personIdentifier`   varchar(128) NOT NULL,
+  `firstRetrievalDate` datetime     DEFAULT NULL,
+  `retrievalStrategy`  varchar(64)  DEFAULT NULL,
+  `source`             varchar(32)  DEFAULT NULL,
+  PRIMARY KEY (`pmid`, `personIdentifier`),
+  KEY `idx_personIdentifier` (`personIdentifier`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+"""
+
+LOAD_COLUMNS = ['pmid', 'personIdentifier', 'firstRetrievalDate',
+                'retrievalStrategy', 'source']
+
+
+def connect_db(max_retries=5, backoff_factor=1):
+    username = os.environ['DB_USERNAME']
+    password = os.environ['DB_PASSWORD']
+    hostname = os.environ['DB_HOST']
+    database = os.environ['DB_NAME']
+    for retry in range(max_retries):
+        try:
+            conn = pymysql.connect(
+                user=username,
+                password=password,
+                database=database,
+                host=hostname,
+                charset='utf8mb4',
+                cursorclass=pymysql.cursors.DictCursor,
+            )
+            logger.info('Connected to database %s on %s', database, hostname)
+            return conn
+        except pymysql.err.MySQLError as err:
+            logger.error('DB connect attempt %d failed: %s', retry + 1, err)
+            time.sleep(backoff_factor * (2 ** retry) + random.uniform(0, 1))
+    raise RuntimeError('Could not connect to database after retries')
+
+
+def epoch_to_datetime_str(frd):
+    """Convert an epoch-seconds value (DynamoDB Decimal/int/str) to a UTC
+    'YYYY-MM-DD HH:MM:SS' string, or None if absent/invalid/out-of-range. frd is
+    stored as UTC; Publication Manager formats it for display."""
+    if frd is None:
+        return None
+    try:
+        secs = int(frd)
+    except (TypeError, ValueError):
+        logger.warning('Unparseable frd value: %r; storing NULL', frd)
+        return None
+    # Reject implausible timestamps (corrupt data) rather than store a bogus year.
+    upper = int(datetime.now(tz=timezone.utc).timestamp()) + 86400  # now + 1 day skew
+    if secs < MIN_EPOCH_SECONDS or secs > upper:
+        logger.warning('Out-of-range frd value: %r; storing NULL', frd)
+        return None
+    try:
+        return datetime.fromtimestamp(secs, tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S')
+    except (OverflowError, OSError, ValueError):
+        logger.warning('Unconvertible frd value: %r; storing NULL', frd)
+        return None
+
+
+def scan_article_provenance(dynamo_table):
+    """Generator that yields pages (lists of items) from a full scan of the
+    ArticleProvenance table. Eventually-consistent read is fine for a nightly
+    snapshot (frd is immutable once written)."""
+    total = 0
+    last_key = None
+    while True:
+        kwargs = {'Limit': SCAN_PAGE_SIZE}
+        if last_key:
+            kwargs['ExclusiveStartKey'] = last_key
+        response = dynamo_table.scan(**kwargs)
+        items = response.get('Items', [])
+        total += len(items)
+        if items:
+            logger.info('Scanned %d items from %s (running total: %d).',
+                        len(items), DYNAMO_TABLE, total)
+            yield items
+        last_key = response.get('LastEvaluatedKey')
+        if not last_key:
+            break
+    logger.info('Finished scanning %s. Total items: %d.', DYNAMO_TABLE, total)
+
+
+def item_to_row(item):
+    """Map one ArticleProvenance item to a row tuple matching LOAD_COLUMNS, or
+    return None to skip (missing uid / non-numeric articleId)."""
+    uid = item.get('uid')
+    if not uid:
+        return None
+    try:
+        pmid = int(item.get('articleId'))
+    except (TypeError, ValueError):
+        return False  # distinguishes bad-pmid from no-uid for counting
+    first_retrieval = epoch_to_datetime_str(item.get('frd'))
+    rs = item.get('rs')
+    src = item.get('src')
+    rs = str(rs)[:64] if rs is not None else None
+    src = str(src)[:32] if src is not None else None
+    return (pmid, str(uid)[:128], first_retrieval, rs, src)
+
+
+def stream_into_staging(conn, cursor, dynamo_table):
+    """Scan ArticleProvenance and INSERT IGNORE each page into the staging table.
+    Streaming keeps peak memory to one page; INSERT IGNORE collapses any
+    (pmid, personIdentifier) duplicate (incl. case-variant uids under the
+    case-insensitive PK) instead of aborting. Returns scan/skip stats."""
+    col_list = ', '.join(f'`{c}`' for c in LOAD_COLUMNS)
+    placeholders = ', '.join(['%s'] * len(LOAD_COLUMNS))
+    sql = f"INSERT IGNORE INTO `{STAGING_TABLE}` ({col_list}) VALUES ({placeholders})"
+
+    scanned = skipped_no_uid = skipped_bad_pmid = 0
+    for page in scan_article_provenance(dynamo_table):
+        scanned += len(page)
+        page_rows = []
+        for item in page:
+            row = item_to_row(item)
+            if row is None:
+                skipped_no_uid += 1
+            elif row is False:
+                skipped_bad_pmid += 1
+            else:
+                page_rows.append(row)
+        if page_rows:
+            cursor.executemany(sql, page_rows)
+            conn.commit()
+
+    cursor.execute(f"SELECT COUNT(*) AS c FROM `{STAGING_TABLE}`")
+    staged = cursor.fetchone()['c']
+    skipped = skipped_no_uid + skipped_bad_pmid
+    logger.info('Scanned %d items; staged %d rows (skipped %d no-uid, %d bad-pmid).',
+                scanned, staged, skipped_no_uid, skipped_bad_pmid)
+    if scanned and (skipped / scanned) > SKIP_RATIO_WARN:
+        logger.warning('High skip ratio: %d/%d (%.1f%%) of scanned items were '
+                       'dropped; staged table may be partial.',
+                       skipped, scanned, 100.0 * skipped / scanned)
+    return {'scanned': scanned, 'staged': staged}
+
+
+def create_staging_table(cursor):
+    """(Re)create the staging table as an empty clone of production."""
+    cursor.execute(CREATE_TARGET_SQL)  # ensure production exists (fresh env)
+    cursor.execute(f"DROP TABLE IF EXISTS `{STAGING_TABLE}`")
+    cursor.execute(f"CREATE TABLE `{STAGING_TABLE}` LIKE `{TARGET_TABLE}`")
+    logger.info('Created staging table %s', STAGING_TABLE)
+
+
+def recover_orphaned_backup(conn, cursor):
+    """Self-heal from a prior run that died after RENAMEing production away but
+    before the swap completed: if production is gone but a backup exists, restore
+    it so we never fabricate an empty production table over a good backup."""
+    cursor.execute(f"SHOW TABLES LIKE '{TARGET_TABLE}'")
+    if cursor.fetchone():
+        return
+    cursor.execute(f"SHOW TABLES LIKE '{BACKUP_TABLE}'")
+    if cursor.fetchone():
+        logger.warning('Production %s missing but %s present (orphaned prior run); '
+                       'restoring backup before proceeding.', TARGET_TABLE, BACKUP_TABLE)
+        cursor.execute(f"RENAME TABLE `{BACKUP_TABLE}` TO `{TARGET_TABLE}`")
+        conn.commit()
+
+
+def validate_staging(cursor, min_rows=MIN_STAGING_ROWS, min_percentage=80):
+    """Guard against replacing a healthy production table with a partial/empty
+    scan. Requires the staging table to meet a row floor and (when production
+    already has data) to be at least min_percentage of the production row count."""
+    cursor.execute(f"SELECT COUNT(*) AS c FROM `{STAGING_TABLE}`")
+    staging_count = cursor.fetchone()['c']
+    cursor.execute(f"SELECT COUNT(*) AS c FROM `{TARGET_TABLE}`")
+    production_count = cursor.fetchone()['c']
+    logger.info('Validation: %s has %d rows, %s has %d rows',
+                STAGING_TABLE, staging_count, TARGET_TABLE, production_count)
+
+    if staging_count < min_rows:
+        logger.error('Validation FAILED: %s has %d rows (minimum %d)',
+                     STAGING_TABLE, staging_count, min_rows)
+        return False
+    if production_count > 0:
+        percentage = (staging_count / production_count) * 100
+        logger.info('Staging is %.1f%% of production', percentage)
+        if percentage < min_percentage:
+            logger.error('Validation FAILED: staging (%d) is only %.1f%% of '
+                         'production (%d); minimum %d%%',
+                         staging_count, percentage, production_count, min_percentage)
+            return False
+    logger.info('Validation PASSED for %s', STAGING_TABLE)
+    return True
+
+
+def atomic_swap(conn, cursor):
+    """Atomically swap staging into production: production -> backup, staging ->
+    production, in a single RENAME TABLE (atomic in MariaDB/InnoDB)."""
+    cursor.execute(f"DROP TABLE IF EXISTS `{BACKUP_TABLE}`")
+    rename_sql = (f"RENAME TABLE `{TARGET_TABLE}` TO `{BACKUP_TABLE}`, "
+                  f"`{STAGING_TABLE}` TO `{TARGET_TABLE}`")
+    logger.info('Executing atomic swap: %s', rename_sql)
+    cursor.execute(rename_sql)
+    conn.commit()
+    logger.info('Atomic swap completed for %s', TARGET_TABLE)
+
+
+def restore_from_backup(conn, cursor):
+    """Rename the backup table back to production if a swap failed mid-flight.
+    Because the swap is a single atomic RENAME, a raised swap means NEITHER table
+    was renamed and the backup was already dropped -- so 'no backup found' here is
+    the expected, SAFE outcome (production was never moved), not a data-loss event."""
+    cursor.execute(f"SHOW TABLES LIKE '{BACKUP_TABLE}'")
+    if not cursor.fetchone():
+        logger.info('No backup table %s to restore (production left untouched).',
+                    BACKUP_TABLE)
+        return
+    cursor.execute(f"SHOW TABLES LIKE '{TARGET_TABLE}'")
+    if cursor.fetchone():
+        cursor.execute(f"DROP TABLE IF EXISTS `{TARGET_TABLE}`")
+    cursor.execute(f"RENAME TABLE `{BACKUP_TABLE}` TO `{TARGET_TABLE}`")
+    conn.commit()
+    logger.info('Restored %s from backup', TARGET_TABLE)
+
+
+def cleanup_staging(conn, cursor):
+    cursor.execute(f"DROP TABLE IF EXISTS `{STAGING_TABLE}`")
+    conn.commit()
+    logger.info('Cleaned up staging table %s', STAGING_TABLE)
+
+
+def main():
+    conn = connect_db()
+    cursor = conn.cursor()
+
+    cfg = Config(retries={'max_attempts': 10, 'mode': 'standard'})
+    dynamo_table = boto3.resource('dynamodb', config=cfg).Table(DYNAMO_TABLE)
+
+    try:
+        recover_orphaned_backup(conn, cursor)
+        create_staging_table(cursor)
+        conn.commit()
+
+        stream_into_staging(conn, cursor, dynamo_table)
+
+        if not validate_staging(cursor):
+            logger.error('Validation failed; aborting swap to protect production.')
+            cleanup_staging(conn, cursor)
+            sys.exit(1)
+
+        try:
+            atomic_swap(conn, cursor)
+        except Exception as swap_err:
+            logger.error('Atomic swap failed: %s; attempting restore.', swap_err)
+            restore_from_backup(conn, cursor)
+            cleanup_staging(conn, cursor)
+            sys.exit(1)
+
+        logger.info('SUCCESS: %s updated with zero downtime.', TARGET_TABLE)
+
+    except (BotoCoreError, ClientError) as e:
+        logger.error('DynamoDB error during %s scan: %s', DYNAMO_TABLE, e)
+        cleanup_staging(conn, cursor)
+        sys.exit(1)
+    except pymysql.err.MySQLError as e:
+        logger.error('Database error: %s', e)
+        try:
+            cleanup_staging(conn, cursor)
+        except Exception:
+            pass
+        sys.exit(1)
+    finally:
+        cursor.close()
+        conn.close()
+        logger.info('Database connection closed.')
+
+
+if __name__ == '__main__':
+    main()

--- a/update/run_all.py
+++ b/update/run_all.py
@@ -109,22 +109,30 @@ def upload_log_to_s3():
 
 # ------------- Main Flow -------------
 def main():
+    # (name, command, non_fatal). non_fatal=True steps log a warning and continue
+    # on failure instead of aborting the pipeline.
     scripts = [
-        ("executeFeatureGenerator", "python3 executeFeatureGenerator.py"),
-        ("retrieveArticles", "python3 retrieveArticles.py"),
-        ("retrieveNIH", "python3 retrieveNIH.py"),
-        ("retrieveReporter", "python3 retrieveReporter.py"),
-        ("nightlyIndexing", "bash run_nightly_indexing.sh"),
-        ("abstractImport", "python3 abstractImport.py"),
-        ("conflictsImport", "python3 conflictsImport.py")
+        ("executeFeatureGenerator", "python3 executeFeatureGenerator.py", False),
+        ("retrieveArticles", "python3 retrieveArticles.py", False),
+        ("retrieveNIH", "python3 retrieveNIH.py", False),
+        ("retrieveReporter", "python3 retrieveReporter.py", False),
+        # article_provenance feeds a PM display field only; nothing downstream
+        # depends on it, so a failure here must not block nightly indexing.
+        ("retrieveArticleProvenance", "python3 retrieveArticleProvenance.py", True),
+        ("nightlyIndexing", "bash run_nightly_indexing.sh", False),
+        ("abstractImport", "python3 abstractImport.py", False),
+        ("conflictsImport", "python3 conflictsImport.py", False)
     ]
 
     overall_success = True
 
-    for name, cmd in scripts:
+    for name, cmd, non_fatal in scripts:
         #ok = run_script(name, cmd)
         ok = run_script(name, cmd, timeout_seconds=int(os.getenv("SCRIPT_TIMEOUT_SECONDS", "15000")))
         if not ok:
+            if non_fatal:
+                logger.warning(f"⚠️ NON-FATAL: {name} failed; continuing pipeline.")
+                continue
             overall_success = False
             logger.error("Stopping pipeline due to script failure.")
             break


### PR DESCRIPTION
Backend/ETL half of **#95**. Adds a nightly step that scans the ReCiter DynamoDB `ArticleProvenance` table into a new pmid-keyed reciterdb table, `article_provenance`, so Publication Manager can display "date a publication was first retrieved" (wcmc-its/ReCiter-Publication-Manager#737).

## What changed
- **`update/retrieveArticleProvenance.py`** (new) — scans `ArticleProvenance`, maps each item to `(pmid, personIdentifier, firstRetrievalDate, retrievalStrategy, source)`, streams pages into an `article_provenance_new` staging table, validates against production, then atomic `RENAME`-swaps. Mirrors the `retrieveNIH.py` staging→swap pattern.
- **`setup/createDatabaseTableReciterDb.sql`** — `article_provenance` DDL for fresh installs.
- **`setup/alter_add_article_provenance_v1.6.sql`** (new) — migration for existing dev/prod databases.
- **`update/run_all.py`** — runs the step before `nightlyIndexing`, **non-fatal** (a failure cannot block the indexing SP; nothing downstream depends on this table).
- **`Dockerfile`** — `COPY` the new script.
- **`README.md`** — document the step (and backfill the already-missing `retrieveReporter` row).

## Key decision: keyed on `(pmid, personIdentifier)`
Issue #95 described `ArticleProvenance` as keyed on `articleId` only ("global, not per-person"). The actual ReCiter source (`reciter.service.dynamo.ArticleProvenanceServiceImpl` + its test) uses a **composite key `uid` (HASH) + `articleId` (RANGE)** — one item per (person, article), so `frd` is per-person. The reciterdb table mirrors that key exactly (no cross-person collapse), per maintainer direction.

Column mapping (DynamoDB → reciterdb):

| DynamoDB attr | column | notes |
|---|---|---|
| `articleId` | `pmid` (`int(11)`) | String PMID → int |
| `uid` | `personIdentifier` (`varchar(128)`) | |
| `frd` | `firstRetrievalDate` (`datetime`) | epoch **seconds**, stored UTC |
| `rs` | `retrievalStrategy` (`varchar(64)`) | |
| `src` | `source` (`varchar(32)`) | |

`ads` (strategy String Set) is intentionally not loaded.

## Robustness
- Streams the scan page-by-page with `INSERT IGNORE` — bounds peak memory to one page (no full-corpus list) and collapses any `(pmid, personIdentifier)` collision instead of aborting the load.
- Validation gate (`min_rows=100` + ≥80% of production) prevents a partial/empty scan from replacing a healthy table.
- `frd` outside a plausible range (pre-2000 / future) is stored NULL.
- Orphaned-backup self-heal at startup; clearer restore logging.

## Verification
- ✅ `py_compile` clean; ✅ the three `article_provenance` definitions (DDL, migration, embedded `CREATE_TARGET_SQL`) are byte-identical; ✅ adversarial multi-agent review (no critical/high findings).
- ⚠️ **Not runtime-tested against a live `ArticleProvenance` table** (no DB/AWS creds in the dev env). Recommend a manual `retrieveArticleProvenance.py` run (or first-nightly check) after the migration is applied.

## 3-place schema checklist (#95)
- [x] DDL in `setup/createDatabaseTableReciterDb.sql`
- [x] applied to **dev** reciterdb (maintainer-confirmed, 2026-06-14)
- [x] applied to **prod** reciterdb (maintainer-confirmed, 2026-06-14)