### PR TITLE
feat(setup): mirror RBAC permission tables + impersonatedByUserID column (#739, #733)

### DIFF
--- a/setup/createDatabaseTableReciterDb.sql
+++ b/setup/createDatabaseTableReciterDb.sql
@@ -51,6 +51,7 @@ CREATE TABLE IF NOT EXISTS `admin_feedback_log` (
   `personIdentifier` varchar(20) DEFAULT NULL,
   `articleIdentifier` int(11) DEFAULT NULL,
   `feedback` varchar(11) DEFAULT NULL,
+  `impersonatedByUserID` int(11) DEFAULT NULL,
   `createTimestamp` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   `modifyTimestamp` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   PRIMARY KEY (`feedbackID`),
@@ -97,6 +98,49 @@ CREATE TABLE IF NOT EXISTS `admin_roles` (
   `createTimestamp` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   `modifyTimestamp` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
   PRIMARY KEY (`roleID`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Data-driven RBAC permission tables.
+-- Mirror of ReCiter-Publication-Manager scripts/migrations/add-permission-tables.sql
+-- (3-places rule). Seed data lives in setup/table_admin_permissions.sql.
+CREATE TABLE IF NOT EXISTS `admin_permissions` (
+  `permissionID` int(11) NOT NULL AUTO_INCREMENT,
+  `permissionKey` varchar(128) NOT NULL,
+  `label` varchar(255) NOT NULL,
+  `description` text DEFAULT NULL,
+  `category` varchar(64) NOT NULL,
+  `createTimestamp` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `modifyTimestamp` timestamp NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
+  PRIMARY KEY (`permissionID`),
+  UNIQUE KEY `uq_permissionKey` (`permissionKey`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `admin_role_permissions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `roleID` int(11) NOT NULL,
+  `permissionID` int(11) NOT NULL,
+  `createTimestamp` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uq_role_permission` (`roleID`,`permissionID`),
+  KEY `idx_roleID` (`roleID`),
+  KEY `idx_permissionID` (`permissionID`),
+  CONSTRAINT `fk_rp_role` FOREIGN KEY (`roleID`) REFERENCES `admin_roles` (`roleID`) ON DELETE CASCADE,
+  CONSTRAINT `fk_rp_permission` FOREIGN KEY (`permissionID`) REFERENCES `admin_permissions` (`permissionID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS `admin_permission_resources` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `permissionID` int(11) NOT NULL,
+  `resourceType` varchar(32) NOT NULL,
+  `resourceKey` varchar(128) NOT NULL,
+  `displayOrder` int(11) NOT NULL DEFAULT 0,
+  `icon` varchar(64) DEFAULT NULL,
+  `label` varchar(255) NOT NULL,
+  `route` varchar(255) DEFAULT NULL,
+  `createTimestamp` timestamp NOT NULL DEFAULT current_timestamp(),
+  PRIMARY KEY (`id`),
+  KEY `idx_pr_permissionID` (`permissionID`),
+  CONSTRAINT `fk_pr_permission` FOREIGN KEY (`permissionID`) REFERENCES `admin_permissions` (`permissionID`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `admin_settings` (

--- a/setup/table_admin_permissions.sql
+++ b/setup/table_admin_permissions.sql
@@ -1,0 +1,56 @@
+-- Seed data for the data-driven RBAC permission tables.
+-- Mirror of the SEED section of ReCiter-Publication-Manager
+-- scripts/migrations/add-permission-tables.sql (3-places rule).
+--
+-- Run ONCE per environment, after createDatabaseTableReciterDb.sql has created
+-- the tables and table_admin_roles.sql has seeded admin_roles. The role->permission
+-- seed joins on admin_roles.roleLabel, so it adapts to whatever roles an
+-- environment defines; 'Curator_Scoped' is a harmless no-op where that role
+-- does not exist.
+
+-- 1. Permissions (7)
+INSERT INTO `admin_permissions` (`permissionKey`, `label`, `description`, `category`) VALUES
+  ('canCurate', 'Curate Publications', 'Accept or reject article suggestions for people', 'Curation'),
+  ('canSearch', 'Search Identities', 'Search and browse the identity directory', 'Navigation'),
+  ('canReport', 'Create Reports', 'Generate publication reports and export data', 'Reporting'),
+  ('canManageUsers', 'Manage Users', 'Create, edit, and deactivate user accounts and assign roles', 'Administration'),
+  ('canConfigure', 'Configuration', 'Edit application settings, labels, and field visibility', 'Administration'),
+  ('canManageNotifications', 'Manage Notifications', 'Configure notification preferences', 'Communication'),
+  ('canManageProfile', 'Manage Profile', 'View and edit user profile information', 'Profile');
+
+-- 2. Role -> permission mappings (reproduces current behavior)
+INSERT INTO `admin_role_permissions` (`roleID`, `permissionID`)
+  SELECT ar.roleID, ap.permissionID FROM admin_roles ar CROSS JOIN admin_permissions ap
+  WHERE ar.roleLabel = 'Superuser';                                                   -- all 7
+INSERT INTO `admin_role_permissions` (`roleID`, `permissionID`)
+  SELECT ar.roleID, ap.permissionID FROM admin_roles ar CROSS JOIN admin_permissions ap
+  WHERE ar.roleLabel = 'Curator_All'                 AND ap.permissionKey IN ('canCurate','canSearch');
+INSERT INTO `admin_role_permissions` (`roleID`, `permissionID`)
+  SELECT ar.roleID, ap.permissionID FROM admin_roles ar CROSS JOIN admin_permissions ap
+  WHERE ar.roleLabel = 'Curator_Self'                AND ap.permissionKey IN ('canCurate');
+INSERT INTO `admin_role_permissions` (`roleID`, `permissionID`)
+  SELECT ar.roleID, ap.permissionID FROM admin_roles ar CROSS JOIN admin_permissions ap
+  WHERE ar.roleLabel = 'Curator_Scoped'              AND ap.permissionKey IN ('canCurate','canSearch');
+INSERT INTO `admin_role_permissions` (`roleID`, `permissionID`)
+  SELECT ar.roleID, ap.permissionID FROM admin_roles ar CROSS JOIN admin_permissions ap
+  WHERE ar.roleLabel = 'Curator_Department'          AND ap.permissionKey IN ('canCurate','canSearch');
+INSERT INTO `admin_role_permissions` (`roleID`, `permissionID`)
+  SELECT ar.roleID, ap.permissionID FROM admin_roles ar CROSS JOIN admin_permissions ap
+  WHERE ar.roleLabel = 'Curator_Department_Delegate' AND ap.permissionKey IN ('canCurate','canSearch');
+INSERT INTO `admin_role_permissions` (`roleID`, `permissionID`)
+  SELECT ar.roleID, ap.permissionID FROM admin_roles ar CROSS JOIN admin_permissions ap
+  WHERE ar.roleLabel = 'Reporter_All'                AND ap.permissionKey IN ('canReport','canSearch');
+
+-- 3. Nav resources (sidebar items)
+INSERT INTO `admin_permission_resources` (`permissionID`, `resourceType`, `resourceKey`, `displayOrder`, `icon`, `label`, `route`)
+  SELECT ap.permissionID, v.resourceType, v.resourceKey, v.displayOrder, v.icon, v.label, v.route
+  FROM admin_permissions ap
+  JOIN (
+    SELECT 'canSearch' AS pk, 'nav' AS resourceType, 'nav_search' AS resourceKey, 1 AS displayOrder, 'Search' AS icon, 'Find People' AS label, '/search' AS route
+    UNION ALL SELECT 'canCurate', 'nav', 'nav_curate', 2, 'LocalLibrary', 'Curate Publications', '/curate'
+    UNION ALL SELECT 'canReport', 'nav', 'nav_report', 3, 'Assessment', 'Create Reports', '/report'
+    UNION ALL SELECT 'canManageNotifications', 'nav', 'nav_notifications', 4, 'NotificationsActive', 'Manage Notifications', '/notifications'
+    UNION ALL SELECT 'canManageProfile', 'nav', 'nav_profile', 5, 'AccountCircle', 'Manage Profile', '/manageprofile'
+    UNION ALL SELECT 'canManageUsers', 'nav', 'nav_users', 6, 'Group', 'Manage Users', '/manageusers'
+    UNION ALL SELECT 'canConfigure', 'nav', 'nav_config', 7, 'Settings', 'Configuration', '/configuration'
+  ) v ON ap.permissionKey = v.pk;


### PR DESCRIPTION
3-places mirror of the ReCiter-Publication-Manager RBAC schema, so a fresh reciterDB built from this repo matches what the app expects. Additive only.

- `createDatabaseTableReciterDb.sql`: add `admin_permissions`, `admin_role_permissions`, `admin_permission_resources`; add `impersonatedByUserID int(11) DEFAULT NULL` to `admin_feedback_log`.
- `table_admin_permissions.sql` (new): permission / role-mapping / nav seed, mirroring the `table_admin_roles.sql` pattern.

Mirrors PM `scripts/migrations/add-permission-tables.sql` (#739) and `add-impersonated-by-feedbacklog.sql` (#733). House style (int(11)/timestamp); functional contract (columns, keys, uniques, FKs) matches the deployed tables. Plain column, no FK, to match dev (applied via the PM migration, FK-less) — the optional FK stays deferred under #733/M3.

Refs #739, #733.