### PR TITLE
authorship_review multi-source migration (v1.6) — Scopus lane [ReCiterDB#102]

### DIFF
--- a/setup/alter_authorship_review_multisource_v1.6.sql
+++ b/setup/alter_authorship_review_multisource_v1.6.sql
@@ -5,8 +5,10 @@
 -- the new Scopus detector lane (ReCiterDB#103 / PM#775) can write authorships
 -- found on documents NOT in PubMed. Adds:
 --   - source        ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed' (+ index)
---   - external_id   VARCHAR(96)  NULL  — DOI-first, numeric Scopus ID fallback
---                                        (EIDs are unstable across record merges)
+--   - external_id   VARCHAR(96)  NULL  — numeric Scopus record ID (dc:identifier minus
+--                                        SCOPUS_ID:); drives the PM Accept articleId
+--                                        "SCOPUS:<id>" + the Scopus record link. DOI lives
+--                                        in `doi`; author_key is DOI-first for merge-stable dedup
 --   - pub_type      VARCHAR(40)  NULL  — Article / Book Chapter / Conference Paper…
 --   - container_id  VARCHAR(96)  NULL  — book base DOI (chapter → book), enables
 --                                        the tab's "N chapters in this book" runs
@@ -55,7 +57,7 @@ SET @sql = (SELECT IF(
 PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
 -- -----------------------------------------------------------------------------
--- external_id VARCHAR(96) NULL — DOI-first, numeric Scopus ID fallback
+-- external_id VARCHAR(96) NULL — numeric Scopus record ID (Accept articleId + record link)
 -- -----------------------------------------------------------------------------
 SET @sql = (SELECT IF(
     (SELECT COUNT(*) FROM information_schema.columns

--- a/setup/alter_authorship_review_multisource_v1.6.sql
+++ b/setup/alter_authorship_review_multisource_v1.6.sql
@@ -1,0 +1,133 @@
+-- =============================================================================
+-- Migration: authorship_review multi-source (v1.6)
+-- =============================================================================
+-- Extends authorship_review from a PubMed-only queue to a multi-source one so
+-- the new Scopus detector lane (ReCiterDB#103 / PM#775) can write authorships
+-- found on documents NOT in PubMed. Adds:
+--   - source        ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed' (+ index)
+--   - external_id   VARCHAR(96)  NULL  — DOI-first, numeric Scopus ID fallback
+--                                        (EIDs are unstable across record merges)
+--   - pub_type      VARCHAR(40)  NULL  — Article / Book Chapter / Conference Paper…
+--   - container_id  VARCHAR(96)  NULL  — book base DOI (chapter → book), enables
+--                                        the tab's "N chapters in this book" runs
+-- and relaxes two existing columns:
+--   - pmid          BIGINT NOT NULL → NULL   (Scopus-only rows have no PMID)
+--   - author_key    VARCHAR(32) → VARCHAR(160) (Scopus keys are longer:
+--                                        `scopus:{doi-or-scopusid}:{position}`)
+--
+-- WHY THIS MIGRATION EXISTS:
+--   The producer (ReCiter Research scripts/aar_db.py) upserts by author_key.
+--   PubMed rows keep `{pmid}:{position}`; Scopus rows use
+--   `scopus:{doi-or-scopusid}:{position}` — up to ~160 chars, and carry no PMID.
+--   Without these changes a Scopus upsert fails on the NOT NULL pmid, the 32-char
+--   author_key truncation, and the missing source/external_id/pub_type/container_id
+--   columns. author_key stays the UNIQUE upsert identity (uq_author_key).
+--
+--   The fresh-build schema (setup/table_authorship_review.sql) is updated in the
+--   same PR to define the table WITH these columns, so new databases are fine.
+--   This migration brings EXISTING databases up to that schema. It must be applied
+--   directly to BOTH reciterdb instances — the producer instance and the separate
+--   dev instance behind reciter-pm-dev (loaded manually) — before the Scopus
+--   detector or the PM Scopus tab runs against them. Merging the PR does NOT run DDL.
+--
+-- DURABILITY: authorship_review is curator state, not a reporting export. It is NOT
+--   in update/updateReciterDB.py's truncate list (`all_tables`) and is not touched
+--   by any nightly stored procedure or ETL step, so these columns persist across
+--   nightly reload. (Verified: the table name appears only in its own CREATE file.)
+--
+-- Safe to run on prod and dev. Every statement is guarded by an information_schema
+-- check (no-op on re-run). Existing rows get source='pubmed' via the column default;
+-- no existing row's data is altered. Additive/relaxing only — nothing is dropped or
+-- narrowed. Run BEFORE the Scopus detector or the PM Scopus tab hits this database.
+-- =============================================================================
+
+SET @db = DATABASE();
+
+-- -----------------------------------------------------------------------------
+-- source ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed'
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'source') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `source` ENUM(''pubmed'',''scopus'') NOT NULL DEFAULT ''pubmed''',
+    'SELECT ''authorship_review.source already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- external_id VARCHAR(96) NULL — DOI-first, numeric Scopus ID fallback
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'external_id') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `external_id` VARCHAR(96) NULL',
+    'SELECT ''authorship_review.external_id already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- pub_type VARCHAR(40) NULL — Scopus subtypeDescription (drives type filter)
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'pub_type') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `pub_type` VARCHAR(40) NULL',
+    'SELECT ''authorship_review.pub_type already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- container_id VARCHAR(96) NULL — book base DOI (enables per-book chapter runs)
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'container_id') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `container_id` VARCHAR(96) NULL',
+    'SELECT ''authorship_review.container_id already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- pmid BIGINT NOT NULL -> NULL (Scopus-only rows have no PMID)
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'pmid' AND is_nullable = 'NO') = 1,
+    'ALTER TABLE authorship_review MODIFY COLUMN `pmid` BIGINT NULL',
+    'SELECT ''authorship_review.pmid already nullable'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- author_key VARCHAR(32) -> VARCHAR(160) (Scopus keys are longer)
+--   VARCHAR(160) utf8mb4 = 640 bytes < 3072-byte InnoDB index prefix limit, so
+--   the uq_author_key UNIQUE index is unaffected by the widen.
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'author_key' AND character_maximum_length < 160) = 1,
+    'ALTER TABLE authorship_review MODIFY COLUMN `author_key` VARCHAR(160) NOT NULL',
+    'SELECT ''authorship_review.author_key already >= 160'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- ix_source index on source
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.statistics
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND index_name = 'ix_source') = 0,
+    'ALTER TABLE authorship_review ADD INDEX `ix_source` (`source`)',
+    'SELECT ''authorship_review.ix_source already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+SELECT column_name, data_type, character_maximum_length, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'authorship_review'
+  AND column_name IN ('source', 'external_id', 'pub_type', 'container_id', 'pmid', 'author_key')
+ORDER BY ordinal_position;

--- a/setup/table_authorship_review.sql
+++ b/setup/table_authorship_review.sql
@@ -45,7 +45,7 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `id`                     BIGINT       NOT NULL AUTO_INCREMENT,
   `source`                 ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed',
   `pmid`                   BIGINT       NULL,                -- NULL for scopus rows
-  `external_id`            VARCHAR(96)  NULL,                -- DOI-first, numeric Scopus ID fallback
+  `external_id`            VARCHAR(96)  NULL,                -- numeric Scopus record ID (Accept articleId + link)
   `author_key`             VARCHAR(160) NOT NULL,            -- `{pmid}:{position}` or `scopus:{doi-or-scopusid}:{position}`
   `pub_type`               VARCHAR(40)  NULL,                -- Article / Book Chapter / Conference Paper…
   `container_id`           VARCHAR(96)  NULL,                -- book base DOI (chapter → book)

--- a/setup/table_authorship_review.sql
+++ b/setup/table_authorship_review.sql
@@ -7,9 +7,16 @@
 -- (see update/updateReciterDB.py `all_tables`) and is not touched by any nightly
 -- stored procedure or ETL step. CREATE TABLE IF NOT EXISTS so re-applying is safe.
 --
--- One row per WCM-affiliated AUTHORSHIP (a PubMed author carrying a WCM affiliation
--- on a publication) that is NOT yet assigned to any identity. Powers the Curator_All
+-- One row per WCM-affiliated AUTHORSHIP (an author carrying a WCM affiliation on a
+-- publication) that is NOT yet assigned to any identity. Powers the Curator_All
 -- `/authorships` tab in ReCiter-Publication-Manager (reads this table via Sequelize).
+--
+-- MULTI-SOURCE (v1.6): `source` distinguishes the PubMed lane from the Scopus lane.
+--   pubmed  — PMID-keyed rows; author_key = `{pmid}:{position}`; resolves to gold standard.
+--   scopus  — documents NOT in PubMed (no PMID); author_key = `scopus:{doi-or-scopusid}:{position}`;
+--             external_id = DOI (else numeric Scopus ID); pub_type = subtypeDescription;
+--             container_id = book base DOI where derivable; resolves to ExternalArticle.
+--   Existing (pre-v1.6) rows are PubMed via the column default.
 --
 -- POPULATED EXTERNALLY (this repo's ETL cannot compute the scores). The producer is
 -- the adversarial-attribution-review pipeline in the ReCiter Research project
@@ -36,8 +43,12 @@
 
 CREATE TABLE IF NOT EXISTS `authorship_review` (
   `id`                     BIGINT       NOT NULL AUTO_INCREMENT,
-  `pmid`                   BIGINT       NOT NULL,
-  `author_key`             VARCHAR(32)  NOT NULL,            -- `pmid:position`
+  `source`                 ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed',
+  `pmid`                   BIGINT       NULL,                -- NULL for scopus rows
+  `external_id`            VARCHAR(96)  NULL,                -- DOI-first, numeric Scopus ID fallback
+  `author_key`             VARCHAR(160) NOT NULL,            -- `{pmid}:{position}` or `scopus:{doi-or-scopusid}:{position}`
+  `pub_type`               VARCHAR(40)  NULL,                -- Article / Book Chapter / Conference Paper…
+  `container_id`           VARCHAR(96)  NULL,                -- book base DOI (chapter → book)
   `author_position`        INT          NULL,
   `author_position_label`  VARCHAR(8)   NULL,                -- first/middle/last
   `wcm_author`             VARCHAR(255) NULL,                -- PubMed author name
@@ -72,6 +83,7 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `last_checked`           DATETIME     NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uq_author_key` (`author_key`),
+  KEY `ix_source` (`source`),
   KEY `ix_pmid` (`pmid`),
   KEY `ix_classification` (`classification`),
   KEY `ix_status` (`status`),


### PR DESCRIPTION
## WP1 — `authorship_review` multi-source migration (ReCiterDB#102)

Extends `authorship_review` from a PubMed-only queue to a multi-source one so the Scopus detector lane (ReCiterDB#103 / PM#775) can write authorships found on documents **not in PubMed**.

### Changes
New `setup/alter_authorship_review_multisource_v1.6.sql` — idempotent, information_schema-guarded ALTERs (v1.5 pattern), plus the matching update to the canonical `setup/table_authorship_review.sql`.

| Column | Change |
|---|---|
| `source` | **new** `ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed'` (+ `ix_source`) |
| `external_id` | **new** `VARCHAR(96) NULL` — DOI-first, numeric Scopus ID fallback (EIDs unstable across record merges) |
| `pub_type` | **new** `VARCHAR(40) NULL` — Scopus `subtypeDescription` (drives the type filter) |
| `container_id` | **new** `VARCHAR(96) NULL` — book base DOI (chapter → book; enables per-book chapter runs) |
| `pmid` | relaxed `BIGINT NOT NULL` → `NULL` (Scopus-only rows have no PMID) |
| `author_key` | widened `VARCHAR(32)` → `VARCHAR(160)` (`scopus:{doi-or-scopusid}:{position}`) |

`author_key` stays the UNIQUE upsert identity. `VARCHAR(160)` utf8mb4 = 640 bytes < the 3072-byte InnoDB index prefix limit, so `uq_author_key` is unaffected.

### Safety
- Additive/relaxing only — nothing dropped or narrowed. Existing rows get `source='pubmed'` via the column default.
- Every statement is information_schema-guarded → safe to re-run (no-op).
- `authorship_review` remains **absent from every truncate list** (`update/updateReciterDB.py` `all_tables`) and all stored procs — verified: the table name appears only in its own CREATE file. Durable across nightly reload.

### ⚠️ Applying the DDL (merging this PR does NOT run it)
Apply `alter_authorship_review_multisource_v1.6.sql` directly to **both** reciterdb instances before the Scopus detector or PM Scopus tab runs against them:
1. Producer instance (`$DB_*` env).
2. The separate dev instance behind `reciter-pm-dev` (loaded manually — **coordinate with Mahender**).

Closes part of ReCiterDB#102.