### PR TITLE
feat(scopus): promote #105 AAR Scopus lane to master (in-cluster producer)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ COPY update/dataTransformer.py ./
 COPY update/executeFeatureGenerator.py ./
 COPY update/run_all.py ./
 
+# AAR Scopus lane (not-in-PubMed WCM authorship detector — weekly, gated in run_all.py)
+COPY update/identity_index.py ./
+COPY update/aar_db.py ./
+COPY update/aar_universe_scopus.py ./
+COPY update/scopus_afids.csv ./
+
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 # Or, if not using requirements.txt:

--- a/kubernetes/k8-cronjob.yaml
+++ b/kubernetes/k8-cronjob.yaml
@@ -69,6 +69,22 @@ spec:
                 configMapKeyRef:
                   name: reciterdb-configmap
                   key: S3_KEY_PREFIX
+            # AAR Scopus lane (weekly, gated in run_all.py) — Scopus AF-ID sweep + PubMed DOI resolution
+            - name: SCOPUS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: scopus-secret
+                  key: SCOPUS_API_KEY
+            - name: SCOPUS_INST_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: scopus-secret
+                  key: SCOPUS_INST_TOKEN
+            - name: PUBMED_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: pubmed-secret
+                  key: PUBMED_API_KEY
             resources:
               requests:
                 memory: 4G

--- a/setup/alter_authorship_review_multisource_v1.6.sql
+++ b/setup/alter_authorship_review_multisource_v1.6.sql
@@ -1,0 +1,133 @@
+-- =============================================================================
+-- Migration: authorship_review multi-source (v1.6)
+-- =============================================================================
+-- Extends authorship_review from a PubMed-only queue to a multi-source one so
+-- the new Scopus detector lane (ReCiterDB#103 / PM#775) can write authorships
+-- found on documents NOT in PubMed. Adds:
+--   - source        ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed' (+ index)
+--   - external_id   VARCHAR(96)  NULL  — DOI-first, numeric Scopus ID fallback
+--                                        (EIDs are unstable across record merges)
+--   - pub_type      VARCHAR(40)  NULL  — Article / Book Chapter / Conference Paper…
+--   - container_id  VARCHAR(96)  NULL  — book base DOI (chapter → book), enables
+--                                        the tab's "N chapters in this book" runs
+-- and relaxes two existing columns:
+--   - pmid          BIGINT NOT NULL → NULL   (Scopus-only rows have no PMID)
+--   - author_key    VARCHAR(32) → VARCHAR(160) (Scopus keys are longer:
+--                                        `scopus:{doi-or-scopusid}:{position}`)
+--
+-- WHY THIS MIGRATION EXISTS:
+--   The producer (ReCiter Research scripts/aar_db.py) upserts by author_key.
+--   PubMed rows keep `{pmid}:{position}`; Scopus rows use
+--   `scopus:{doi-or-scopusid}:{position}` — up to ~160 chars, and carry no PMID.
+--   Without these changes a Scopus upsert fails on the NOT NULL pmid, the 32-char
+--   author_key truncation, and the missing source/external_id/pub_type/container_id
+--   columns. author_key stays the UNIQUE upsert identity (uq_author_key).
+--
+--   The fresh-build schema (setup/table_authorship_review.sql) is updated in the
+--   same PR to define the table WITH these columns, so new databases are fine.
+--   This migration brings EXISTING databases up to that schema. It must be applied
+--   directly to BOTH reciterdb instances — the producer instance and the separate
+--   dev instance behind reciter-pm-dev (loaded manually) — before the Scopus
+--   detector or the PM Scopus tab runs against them. Merging the PR does NOT run DDL.
+--
+-- DURABILITY: authorship_review is curator state, not a reporting export. It is NOT
+--   in update/updateReciterDB.py's truncate list (`all_tables`) and is not touched
+--   by any nightly stored procedure or ETL step, so these columns persist across
+--   nightly reload. (Verified: the table name appears only in its own CREATE file.)
+--
+-- Safe to run on prod and dev. Every statement is guarded by an information_schema
+-- check (no-op on re-run). Existing rows get source='pubmed' via the column default;
+-- no existing row's data is altered. Additive/relaxing only — nothing is dropped or
+-- narrowed. Run BEFORE the Scopus detector or the PM Scopus tab hits this database.
+-- =============================================================================
+
+SET @db = DATABASE();
+
+-- -----------------------------------------------------------------------------
+-- source ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed'
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'source') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `source` ENUM(''pubmed'',''scopus'') NOT NULL DEFAULT ''pubmed''',
+    'SELECT ''authorship_review.source already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- external_id VARCHAR(96) NULL — DOI-first, numeric Scopus ID fallback
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'external_id') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `external_id` VARCHAR(96) NULL',
+    'SELECT ''authorship_review.external_id already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- pub_type VARCHAR(40) NULL — Scopus subtypeDescription (drives type filter)
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'pub_type') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `pub_type` VARCHAR(40) NULL',
+    'SELECT ''authorship_review.pub_type already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- container_id VARCHAR(96) NULL — book base DOI (enables per-book chapter runs)
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'container_id') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `container_id` VARCHAR(96) NULL',
+    'SELECT ''authorship_review.container_id already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- pmid BIGINT NOT NULL -> NULL (Scopus-only rows have no PMID)
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'pmid' AND is_nullable = 'NO') = 1,
+    'ALTER TABLE authorship_review MODIFY COLUMN `pmid` BIGINT NULL',
+    'SELECT ''authorship_review.pmid already nullable'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- author_key VARCHAR(32) -> VARCHAR(160) (Scopus keys are longer)
+--   VARCHAR(160) utf8mb4 = 640 bytes < 3072-byte InnoDB index prefix limit, so
+--   the uq_author_key UNIQUE index is unaffected by the widen.
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'author_key' AND character_maximum_length < 160) = 1,
+    'ALTER TABLE authorship_review MODIFY COLUMN `author_key` VARCHAR(160) NOT NULL',
+    'SELECT ''authorship_review.author_key already >= 160'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- ix_source index on source
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.statistics
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND index_name = 'ix_source') = 0,
+    'ALTER TABLE authorship_review ADD INDEX `ix_source` (`source`)',
+    'SELECT ''authorship_review.ix_source already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+SELECT column_name, data_type, character_maximum_length, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'authorship_review'
+  AND column_name IN ('source', 'external_id', 'pub_type', 'container_id', 'pmid', 'author_key')
+ORDER BY ordinal_position;

--- a/setup/table_authorship_review.sql
+++ b/setup/table_authorship_review.sql
@@ -7,9 +7,16 @@
 -- (see update/updateReciterDB.py `all_tables`) and is not touched by any nightly
 -- stored procedure or ETL step. CREATE TABLE IF NOT EXISTS so re-applying is safe.
 --
--- One row per WCM-affiliated AUTHORSHIP (a PubMed author carrying a WCM affiliation
--- on a publication) that is NOT yet assigned to any identity. Powers the Curator_All
+-- One row per WCM-affiliated AUTHORSHIP (an author carrying a WCM affiliation on a
+-- publication) that is NOT yet assigned to any identity. Powers the Curator_All
 -- `/authorships` tab in ReCiter-Publication-Manager (reads this table via Sequelize).
+--
+-- MULTI-SOURCE (v1.6): `source` distinguishes the PubMed lane from the Scopus lane.
+--   pubmed  — PMID-keyed rows; author_key = `{pmid}:{position}`; resolves to gold standard.
+--   scopus  — documents NOT in PubMed (no PMID); author_key = `scopus:{doi-or-scopusid}:{position}`;
+--             external_id = DOI (else numeric Scopus ID); pub_type = subtypeDescription;
+--             container_id = book base DOI where derivable; resolves to ExternalArticle.
+--   Existing (pre-v1.6) rows are PubMed via the column default.
 --
 -- POPULATED EXTERNALLY (this repo's ETL cannot compute the scores). The producer is
 -- the adversarial-attribution-review pipeline in the ReCiter Research project
@@ -36,8 +43,12 @@
 
 CREATE TABLE IF NOT EXISTS `authorship_review` (
   `id`                     BIGINT       NOT NULL AUTO_INCREMENT,
-  `pmid`                   BIGINT       NOT NULL,
-  `author_key`             VARCHAR(32)  NOT NULL,            -- `pmid:position`
+  `source`                 ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed',
+  `pmid`                   BIGINT       NULL,                -- NULL for scopus rows
+  `external_id`            VARCHAR(96)  NULL,                -- DOI-first, numeric Scopus ID fallback
+  `author_key`             VARCHAR(160) NOT NULL,            -- `{pmid}:{position}` or `scopus:{doi-or-scopusid}:{position}`
+  `pub_type`               VARCHAR(40)  NULL,                -- Article / Book Chapter / Conference Paper…
+  `container_id`           VARCHAR(96)  NULL,                -- book base DOI (chapter → book)
   `author_position`        INT          NULL,
   `author_position_label`  VARCHAR(8)   NULL,                -- first/middle/last
   `wcm_author`             VARCHAR(255) NULL,                -- PubMed author name
@@ -72,6 +83,7 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `last_checked`           DATETIME     NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `uq_author_key` (`author_key`),
+  KEY `ix_source` (`source`),
   KEY `ix_pmid` (`pmid`),
   KEY `ix_classification` (`classification`),
   KEY `ix_status` (`status`),

--- a/update/aar_db.py
+++ b/update/aar_db.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+Authorship Review — reciterdb sink (Phase A of AUTHORSHIP_REVIEW_PM_PLAN.md).
+
+Creates and writes the `authorship_review` table in the reciterdb that Publication
+Manager reads (env DB_*). PM gets a Curator_All `/authorships` tab that reads this
+table; the AAR pipeline (gate/matcher/scorer) is the producer.
+
+The table is the durable, curator-facing store: the producer owns the scoring/
+classification columns (refreshed each run via UPSERT) and NEVER overwrites a
+curator-set `status` (assigned/accepted/rejected/dismissed/snoozed) or its
+resolution/reviewer/note. New authorships are inserted `status='open'`.
+
+NOTE (persistence): this is a PM-app-side table like `admin_users`, NOT a nightly
+reporting export — it must be excluded from the reciterdb nightly-rebuild drop scope
+so curator decisions survive. `create_table()` is CREATE TABLE IF NOT EXISTS, so a
+re-run is a no-op if it already exists.
+
+Usage:
+  python aar_db.py --create        # create the table + indexes (idempotent)
+  python aar_db.py --describe      # show columns + row count
+"""
+import argparse, json, os
+
+from sqlalchemy import create_engine, text
+
+TABLE = "authorship_review"
+
+# producer-owned columns refreshed on every UPSERT (curator columns are preserved)
+_REFRESH_COLS = [
+    "source", "external_id", "pub_type", "container_id",
+    "author_position", "author_position_label", "wcm_author", "author_affiliation",
+    "entrez_date", "title", "journal", "doi", "classification",
+    "top_cwid", "top_name", "top_person_type", "top_dept",
+    "top_fg_score", "top_io_score", "top_confidence", "top_cohort_size",
+    "top_given_match", "top_affil_match", "n_candidates", "single_candidate",
+    "candidate_cwids_json", "last_refreshed",
+]
+# full insert column set (curator columns default on first insert)
+_INSERT_COLS = ["pmid", "author_key"] + _REFRESH_COLS + [
+    "status", "first_seen", "last_checked"]
+
+_ENGINE = None
+
+
+def engine():
+    global _ENGINE
+    if _ENGINE is None:
+        _ENGINE = create_engine(
+            f"mysql+pymysql://{os.environ['DB_USERNAME']}:{os.environ['DB_PASSWORD']}"
+            f"@{os.environ['DB_HOST']}/{os.environ['DB_NAME']}",
+            connect_args={"connect_timeout": 15}, pool_pre_ping=True)
+    return _ENGINE
+
+
+DDL = f"""
+CREATE TABLE IF NOT EXISTS {TABLE} (
+  id                     BIGINT       NOT NULL AUTO_INCREMENT,
+  source                 ENUM('pubmed','scopus') NOT NULL DEFAULT 'pubmed',
+  pmid                   BIGINT       NULL,
+  external_id            VARCHAR(96)  NULL,
+  author_key             VARCHAR(160) NOT NULL,
+  pub_type               VARCHAR(40)  NULL,
+  container_id           VARCHAR(96)  NULL,
+  author_position        INT          NULL,
+  author_position_label  VARCHAR(8)   NULL,
+  wcm_author             VARCHAR(255) NULL,
+  author_affiliation     TEXT         NULL,
+  entrez_date            DATE         NULL,
+  title                  TEXT         NULL,
+  journal                VARCHAR(512) NULL,
+  doi                    VARCHAR(255) NULL,
+  classification         ENUM('assigned','suggested','buried','absent') NULL,
+  top_cwid               VARCHAR(32)  NULL,
+  top_name               VARCHAR(255) NULL,
+  top_person_type        VARCHAR(64)  NULL,
+  top_dept               VARCHAR(255) NULL,
+  top_fg_score           FLOAT        NULL,
+  top_io_score           FLOAT        NULL,
+  top_confidence         FLOAT        NULL,
+  top_cohort_size        INT          NULL,
+  top_given_match        VARCHAR(16)  NULL,
+  top_affil_match        TINYINT(1)   NULL,
+  n_candidates           INT          NULL,
+  single_candidate       TINYINT(1)   NULL,
+  candidate_cwids_json   LONGTEXT     NULL,
+  status                 ENUM('open','assigned','accepted','rejected','dismissed','snoozed')
+                                      NOT NULL DEFAULT 'open',
+  resolution_cwid        VARCHAR(32)  NULL,
+  reviewer               VARCHAR(64)  NULL,
+  note                   TEXT         NULL,
+  snooze_until           DATE         NULL,
+  resolved_at            DATETIME     NULL,
+  first_seen             DATETIME     NULL,
+  last_refreshed         DATETIME     NULL,
+  last_checked           DATETIME     NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY uq_author_key (author_key),
+  KEY ix_source (source),
+  KEY ix_pmid (pmid),
+  KEY ix_classification (classification),
+  KEY ix_status (status),
+  KEY ix_single_candidate (single_candidate),
+  KEY ix_top_io_score (top_io_score),
+  KEY ix_entrez_date (entrez_date),
+  KEY ix_top_cwid (top_cwid)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+"""
+
+
+def create_table():
+    with engine().begin() as c:
+        c.execute(text(DDL))
+
+
+def upsert(rows):
+    """Insert/update authorship rows by author_key. Refreshes producer-owned columns;
+    PRESERVES curator status/resolution/reviewer/note/snooze on existing rows."""
+    if not rows:
+        return 0
+    cols = ", ".join(_INSERT_COLS)
+    placeholders = ", ".join(f":{c}" for c in _INSERT_COLS)
+    updates = ", ".join(f"{c}=VALUES({c})" for c in _REFRESH_COLS)
+    # also advance last_checked on refresh; never touch status/resolution_*/reviewer/note/snooze
+    stmt = text(f"INSERT INTO {TABLE} ({cols}) VALUES ({placeholders}) "
+                f"ON DUPLICATE KEY UPDATE {updates}, last_checked=VALUES(last_checked)")
+    n = 0
+    with engine().begin() as c:
+        for i in range(0, len(rows), 500):
+            chunk = rows[i:i + 500]
+            c.execute(stmt, [{k: r.get(k) for k in _INSERT_COLS} for r in chunk])
+            n += len(chunk)
+    return n
+
+
+def _describe():
+    with engine().connect() as c:
+        cols = c.execute(text(
+            "SELECT column_name, column_type FROM information_schema.columns "
+            "WHERE table_schema=:d AND table_name=:t ORDER BY ordinal_position"),
+            {"d": os.environ["DB_NAME"], "t": TABLE}).fetchall()
+        if not cols:
+            print(f"{TABLE} does not exist")
+            return
+        print(f"{TABLE} — {len(cols)} columns:")
+        for name, typ in cols:
+            print(f"  {name:24} {typ}")
+        n = c.execute(text(f"SELECT COUNT(*) FROM {TABLE}")).scalar()
+        print(f"rows: {n}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--create", action="store_true")
+    ap.add_argument("--describe", action="store_true")
+    args = ap.parse_args()
+    if args.create:
+        create_table()
+        print(f"{TABLE} ready")
+    if args.describe:
+        _describe()
+    if not (args.create or args.describe):
+        ap.error("use --create and/or --describe")
+
+
+if __name__ == "__main__":
+    main()

--- a/update/aar_universe_scopus.py
+++ b/update/aar_universe_scopus.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""
+Adversarial Attribution Review — Scopus lane detector (in-cluster copy).
+
+VENDORED from the ReCiter Research producer into the reciterdb CronJob image so the
+Scopus not-in-PubMed sweep runs in the cluster (weekly, gated in run_all.py) instead
+of the Mac cron. Self-contained by design: it imports only `identity_index` (the
+roster) and `aar_db` (the sink) — NOT the PubMed-lane modules (aar_universe /
+aar_matcher / adversarial_attribution_review), so the image needs no xgboost/S3/models.
+DOI->PubMed resolution is inlined below (throttled E-utilities esearch).
+
+Finds WCM-affiliated authorships on documents that are NOT in PubMed via an
+institution-wide Scopus AF-ID sweep, matches each against the identity roster, and
+upserts them into reciterdb `authorship_review` with source='scopus'. The PM
+Authorships tab (WP3) lets curators Accept them as ExternalArticle records (no PMID
+-> not gold standard). DB-only sink: no CSV ledger for this lane.
+
+Per-doc pipeline (probe-verified — analysis/.../2026-07-03-scopus-probe/):
+  1. Sweep Scopus COMPLETE view for the family AF-IDs over an ORIG-LOAD-DATE window.
+  2. Drop docs carrying a Scopus pubmed-id (the PubMed lane owns them).
+  3. Resolve remaining DOIs against PubMed ([DOI] esearch); resolved -> drop.
+     What's left is the Scopus-only lane (~1% have no DOI -> keyed by numeric Scopus ID).
+  4. Per-author WCM tagging (afid in the family set) -> match via identity_index.
+  5. Upsert via aar_db (source='scopus', external_id=numeric-id|DOI, pmid=NULL).
+  6. Re-check: open scopus rows whose DOI is now in PubMed are resolved out.
+
+Windowing (in-cluster default): rolling short-lag window (Decision A) — each weekly
+run sweeps ORIG-LOAD-DATE over [today-90d, today-14d]. New Scopus authorships surface
+within ~1-2 weeks of load; the lag lets Scopus<->PubMed links begin settling before
+we write; the re-check resolves out any that later become PubMed-reachable.
+
+Env (never printed): SCOPUS_API_KEY, SCOPUS_INST_TOKEN (inst token REQUIRED — key
+alone -> 401), PUBMED_API_KEY (DOI resolution), DB_* (identity roster + sink).
+
+Usage:
+  python aar_universe_scopus.py --selftest                 # offline pure-function checks
+  python aar_universe_scopus.py --mode rolling --apply     # weekly cron: [today-90d,today-14d]
+  python aar_universe_scopus.py --month 2026-05            # dry-run one month (vs probe ranges)
+"""
+import argparse, calendar, csv, json, os, re, sys, time
+from datetime import date, datetime, timedelta
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from identity_index import IdentityIndex   # source-agnostic identity roster
+import aar_db                              # shared authorship_review upsert sink
+
+SCOPUS_SEARCH = "https://api.elsevier.com/content/search/scopus"
+SCOPUS_KEY = os.environ.get("SCOPUS_API_KEY")
+SCOPUS_TOKEN = os.environ.get("SCOPUS_INST_TOKEN")
+
+# family AF-ID set ships alongside this script in the image (Dockerfile COPY).
+DEFAULT_AFID_LIST = os.path.join(os.path.dirname(os.path.abspath(__file__)), "scopus_afids.csv")
+
+# afid 119027669 "Weill Institute for Neurosciences" is a UCSF entity (no city, added by a
+# "Weill" affil-search rather than the home list). Including it would tag UCSF authors as WCM.
+EXCLUDE_AFIDS = {"119027669"}
+
+AFID_CHUNK = 40      # >40 AF-ID() OR-clauses per query -> HTTP 400
+PAGE = 25            # COMPLETE view caps count at 25/page (26+ -> 400 INVALID_INPUT)
+SLEEP = 0.3          # polite Scopus throttle between pages
+
+# ---- inline PubMed E-utilities (avoid importing the PubMed-lane aar_universe) ----
+EUTILS = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils"
+_PUBMED_API_KEY = os.environ.get("PUBMED_API_KEY")
+_PM_SLEEP = 0.12 if _PUBMED_API_KEY else 0.34   # 10 req/s with key, 3/s without
+
+
+def _pubmed_count(term):
+    """esearch hit-count for a PubMed term (throttled, retrying). Returns 0 on any
+    persistent failure — the safe direction: an unresolved DOI stays a scopus row and
+    is re-checked next run rather than being silently dropped."""
+    params = {"db": "pubmed", "term": term, "retmax": 1, "retmode": "json",
+              "tool": "reciterdb-aar-scopus", "email": os.environ.get("NCBI_EMAIL", "")}
+    if _PUBMED_API_KEY:
+        params["api_key"] = _PUBMED_API_KEY
+    for attempt in range(5):
+        try:
+            r = requests.get(f"{EUTILS}/esearch.fcgi", params=params, timeout=60)
+            if r.status_code == 200:
+                return int(r.json()["esearchresult"]["count"])
+            if r.status_code in (429, 500, 502, 503, 504):
+                time.sleep(1.5 * (attempt + 1))
+                continue
+            r.raise_for_status()
+        except (requests.RequestException, KeyError, ValueError, TypeError):
+            if attempt == 4:
+                return 0
+            time.sleep(1.5 * (attempt + 1))
+    return 0
+
+
+def doi_in_pubmed(doi):
+    return bool(doi) and _pubmed_count(f'"{doi}"[DOI]') > 0
+
+
+# ---- tiny local helpers -----------------------------------------------------
+def _position_label(i, n):
+    return "first" if i == 0 else "last" if i == n - 1 else "middle"
+
+
+def _trunc(s, n):
+    return s[:n] if isinstance(s, str) and len(s) > n else s
+
+
+def _compact(cands):
+    keep = ("cwid", "name", "person_type", "dept", "given_match", "affil_dept_match",
+            "cohort_size", "confidence")
+    return [{k: c.get(k) for k in keep} for c in cands]
+
+
+def _as_list(v):
+    return v if isinstance(v, list) else [] if v is None else [v]
+
+
+# ---- family AF-ID set -------------------------------------------------------
+def load_family_afids(path=DEFAULT_AFID_LIST):
+    fam = set()
+    with open(path, newline="") as fh:
+        for row in csv.DictReader(fh):
+            a = (row.get("afid") or "").strip()
+            if a and a not in EXCLUDE_AFIDS:
+                fam.add(a)
+    if not fam:
+        raise RuntimeError(f"no afids loaded from {path}")
+    return fam
+
+
+# ---- Scopus search ----------------------------------------------------------
+def _scopus_get(query, start):
+    headers = {"X-ELS-APIKey": SCOPUS_KEY, "X-ELS-Insttoken": SCOPUS_TOKEN,
+               "Accept": "application/json"}
+    params = {"query": query, "view": "COMPLETE", "count": PAGE, "start": start}
+    for attempt in range(5):
+        try:
+            r = requests.get(SCOPUS_SEARCH, headers=headers, params=params, timeout=60)
+            if r.status_code == 200:
+                return r.json()
+            if r.status_code in (429, 500, 502, 503, 504):
+                time.sleep(2 * (attempt + 1))
+                continue
+            r.raise_for_status()
+        except requests.RequestException:
+            if attempt == 4:
+                raise
+            time.sleep(2 * (attempt + 1))
+    raise RuntimeError("Scopus search failed after retries")
+
+
+def _chunks(seq, n):
+    seq = list(seq)
+    for i in range(0, len(seq), n):
+        yield seq[i:i + n]
+
+
+def build_query(afids, aft, bef):
+    clause = " OR ".join(f"AF-ID({a})" for a in afids)
+    return f"({clause}) AND ORIG-LOAD-DATE AFT {aft} AND ORIG-LOAD-DATE BEF {bef}"
+
+
+def sweep(family, aft, bef, progress=True):
+    """All family docs in the ORIG-LOAD-DATE window, deduped by EID across AF-ID chunks."""
+    by_eid = {}
+    for ci, chunk in enumerate(_chunks(sorted(family), AFID_CHUNK), 1):
+        query = build_query(chunk, aft, bef)
+        start = 0
+        while True:
+            res = _scopus_get(query, start).get("search-results", {})
+            entries = res.get("entry", []) or []
+            if len(entries) == 1 and "error" in entries[0]:
+                break                                    # empty result set
+            for e in entries:
+                if e.get("eid"):
+                    by_eid[e["eid"]] = e
+            total = int(res.get("opensearch:totalResults", 0) or 0)
+            start += PAGE
+            if start >= total or not entries:
+                break
+            time.sleep(SLEEP)
+        if progress:
+            print(f"  chunk {ci}: {len(chunk)} afids -> {len(by_eid)} docs so far", flush=True)
+    return list(by_eid.values())
+
+
+# ---- parsing ----------------------------------------------------------------
+def _numeric_scopus_id(eid):
+    """'2-s2.0-105037523511' -> '105037523511' (EID minus the '2-s2.0-' prefix)."""
+    return eid.split("-s2.0-")[-1] if eid else None
+
+
+def _container_doi(doi, pub_type):
+    """Book-chapter DOIs look like '10.1201/9781003735878-24' -> base '...9781003735878'."""
+    if not doi or not pub_type or "chapter" not in pub_type.lower():
+        return None
+    m = re.match(r"^(.*)-\d+$", doi)
+    return m.group(1) if m else None
+
+
+def _affil_names(entry):
+    """afid -> 'AffilName, City' from the doc-level affiliation array (COMPLETE view)."""
+    out = {}
+    for af in _as_list(entry.get("affiliation")):
+        aid = af.get("afid")
+        if aid:
+            out[aid] = ", ".join(x for x in (af.get("affilname"),
+                                             af.get("affiliation-city")) if x)
+    return out
+
+
+def wcm_authorships(entry, family):
+    """Yield (i, n, author-for-matcher, family_hits) for authors whose afid is in `family`."""
+    authors = _as_list(entry.get("author"))
+    affil = _affil_names(entry)
+    n = len(authors)
+    for i, au in enumerate(authors):
+        afids = [d.get("$") for d in _as_list(au.get("afid")) if d.get("$")]
+        hits = [a for a in afids if a in family]
+        if not hits:
+            continue
+        yield i, n, {
+            "last": au.get("surname"), "fore": au.get("given-name"),
+            "initials": au.get("initials"),
+            "affiliations": [affil[a] for a in afids if a in affil],
+        }, hits
+
+
+def _build_row(entry, i, n, author, top, cands, run_ts):
+    doi = entry.get("prism:doi")
+    sid = _numeric_scopus_id(entry.get("eid"))
+    dedup = doi or sid          # author_key identity: DOI-first, stable across Scopus record merges
+    pub_type = entry.get("subtypeDescription")
+    cohort = top.get("cohort_size") if top else None
+    return {
+        "source": "scopus", "pmid": None,
+        # numeric Scopus record id -> the PM Accept builds articleId "SCOPUS:<external_id>"
+        # and the "Scopus record" link. The DOI lives in `doi`; author_key stays DOI-first.
+        "external_id": _trunc(sid or doi, 96),
+        "author_key": _trunc(f"scopus:{dedup}:{i}", 160),
+        "pub_type": _trunc(pub_type, 40),
+        "container_id": _container_doi(doi, pub_type),
+        "author_position": i + 1, "author_position_label": _position_label(i, n),
+        "wcm_author": _trunc(" ".join(x for x in (author.get("fore"), author.get("last")) if x)
+                             or author.get("initials") or author.get("last"), 255),
+        "author_affiliation": " | ".join(author.get("affiliations") or []),
+        "entrez_date": entry.get("prism:coverDate"),   # Scopus has no entrez date; coverDate ~ recency
+        "title": entry.get("dc:title"),
+        "journal": _trunc(entry.get("prism:publicationName"), 512),
+        "doi": _trunc(doi, 255),
+        "classification": "absent",                    # no PMID -> production never scored it
+        "top_cwid": top["cwid"] if top else None,
+        "top_name": _trunc(top["name"], 255) if top else None,
+        "top_person_type": _trunc(top["person_type"], 64) if top else None,
+        "top_dept": _trunc(top["dept"], 255) if top else None,
+        "top_fg_score": None, "top_io_score": None,    # scopus rail shows neither
+        "top_confidence": top["confidence"] if top else None,
+        "top_cohort_size": cohort,
+        "top_given_match": top["given_match"] if top else None,
+        "top_affil_match": int(bool(top["affil_dept_match"])) if top else None,
+        "n_candidates": len(cands), "single_candidate": int(cohort == 1) if cohort else None,
+        "candidate_cwids_json": json.dumps(_compact(cands)),
+        "status": "open", "first_seen": run_ts,
+        "last_checked": run_ts, "last_refreshed": run_ts,
+    }
+
+
+# ---- re-check open scopus rows ----------------------------------------------
+def recheck_open_scopus(run_ts):
+    """Open scopus rows whose DOI is now PubMed-reachable are resolved out — the PubMed
+    lane will surface them if still orphaned. Guarded on status='open' so a curator's
+    accept/reject is never clobbered. (No dedicated 'resolved' ENUM value; dismissed +
+    an auto note is the removal-from-queue state.)"""
+    from sqlalchemy import text
+    eng = aar_db.engine()
+    with eng.connect() as c:
+        rows = c.execute(text(
+            "SELECT author_key, doi FROM authorship_review "
+            "WHERE source='scopus' AND status='open' AND doi IS NOT NULL")).mappings().all()
+    resolved = 0
+    for r in rows:
+        if doi_in_pubmed(r["doi"]):
+            with eng.begin() as c:
+                c.execute(text(
+                    "UPDATE authorship_review SET status='dismissed', resolved_at=:ts, "
+                    "note=CONCAT('auto: DOI now in PubMed (', :d, ')') "
+                    "WHERE author_key=:k AND status='open'"),
+                    {"ts": run_ts, "d": r["doi"], "k": r["author_key"]})
+            resolved += 1
+        time.sleep(_PM_SLEEP)
+    return resolved
+
+
+# ---- driver -----------------------------------------------------------------
+def run(aft, bef, apply_writes=False, afid_list=DEFAULT_AFID_LIST, recheck=True, idx=None):
+    run_ts = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    family = load_family_afids(afid_list)
+
+    print(f"[1/5] Scopus sweep: {len(family)} family afids, ORIG-LOAD-DATE {aft}..{bef}",
+          flush=True)
+    docs = sweep(family, aft, bef)
+    print(f"      {len(docs)} family docs", flush=True)
+
+    no_pmid = [d for d in docs if not str(d.get("pubmed-id") or "").strip()]
+    print(f"[2/5] {len(docs) - len(no_pmid)} carry a Scopus PMID (dropped); "
+          f"{len(no_pmid)} no-PMID", flush=True)
+
+    print("[3/5] Resolving no-PMID DOIs against PubMed ...", flush=True)
+    scopus_only, resolved = [], 0
+    for d in no_pmid:
+        doi = d.get("prism:doi")
+        if doi:
+            hit = doi_in_pubmed(doi)
+            time.sleep(_PM_SLEEP)
+            if hit:
+                resolved += 1
+                continue
+        scopus_only.append(d)                          # no DOI (~1%) kept, keyed by scopus id
+    print(f"      {resolved} resolved to PubMed by DOI (dropped); "
+          f"{len(scopus_only)} SCOPUS-ONLY", flush=True)
+
+    print("[4/5] Matching WCM authorships against the identity roster ...", flush=True)
+    if idx is None:
+        idx = IdentityIndex.load()
+    rows, unmatched = [], 0
+    for d in scopus_only:
+        for i, n, au, _ in wcm_authorships(d, family):
+            cands, _ = idx.candidates(au["last"], au["fore"], au["initials"],
+                                      au["affiliations"], top_k=5)
+            top = cands[0] if cands else None
+            if top is None:
+                unmatched += 1                         # nothing to assign (v1 skips unmatched)
+                continue
+            rows.append(_build_row(d, i, n, au, top, cands, run_ts))
+    print(f"      {len(rows)} matched authorships; {unmatched} unmatched (skipped)", flush=True)
+
+    if apply_writes:
+        n = aar_db.upsert(rows)
+        print(f"[5/5] upserted {n} scopus authorships -> reciterdb.authorship_review", flush=True)
+        if recheck:
+            print(f"      re-check: {recheck_open_scopus(run_ts)} open scopus rows resolved out",
+                  flush=True)
+    else:
+        print(f"[5/5] DRY-RUN: {len(rows)} rows NOT written (pass --apply to upsert)", flush=True)
+
+    return {"window": {"aft": aft, "bef": bef}, "family_docs": len(docs),
+            "no_pmid": len(no_pmid), "doi_resolved_pubmed": resolved,
+            "scopus_only": len(scopus_only), "matched_rows": len(rows),
+            "unmatched": unmatched}
+
+
+# ---- windows ----------------------------------------------------------------
+def rolling_window(today=None, lag_days=14, span_days=90):
+    """Decision A (in-cluster default): sweep ORIG-LOAD-DATE over [today-span_days,
+    today-lag_days] (~76-day rolling window, lagged so Scopus<->PubMed links begin
+    settling). Weekly cadence; overlapping windows are idempotent via the author_key
+    upsert, so a re-run just refreshes the same rows."""
+    today = today or date.today()
+    aft = (today - timedelta(days=span_days)).strftime("%Y%m%d")
+    bef = (today - timedelta(days=lag_days)).strftime("%Y%m%d")
+    return aft, bef
+
+
+def month_window(year, month):
+    """(AFT, BEF) YYYYMMDD exclusive bounds spanning the given calendar month."""
+    first = date(year, month, 1)
+    last = date(year, month, calendar.monthrange(year, month)[1])
+    return ((first - timedelta(days=1)).strftime("%Y%m%d"),
+            (last + timedelta(days=1)).strftime("%Y%m%d"))
+
+
+def recurring_month(today=None):
+    """One-window-lag: a run in month M sweeps loads of month M-2."""
+    today = today or date.today()
+    y, m = today.year, today.month - 2
+    while m <= 0:
+        m += 12
+        y -= 1
+    return y, m
+
+
+def month_range(start, end):
+    """Inclusive list of (year, month) tuples from start=(y,m) to end=(y,m)."""
+    (sy, sm), (ey, em) = start, end
+    out, y, m = [], sy, sm
+    while (y, m) <= (ey, em):
+        out.append((y, m))
+        m += 1
+        if m > 12:
+            m, y = 1, y + 1
+    return out
+
+
+def initial_months(years=5, today=None):
+    """Backfill window: monthly slices spanning `years` back to the M-2 lag boundary."""
+    ey, em = recurring_month(today)          # newest month we sweep (one-window-lag)
+    return month_range((ey - years, em), (ey, em))
+
+
+def run_backfill(months, apply_writes=False, afid_list=DEFAULT_AFID_LIST):
+    """Backfill driver: sweep each calendar month once, sharing one identity index (the
+    35k-row roster loads once, not per month). The open-row re-check runs ONCE at the end
+    (only when applying). Idempotent per month via the author_key upsert — a run that dies
+    partway resumes with `--from <next-month> --to <end-month>`."""
+    idx = IdentityIndex.load()
+    print(f"Backfill: {len(months)} months, {months[0][0]}-{months[0][1]:02d} .. "
+          f"{months[-1][0]}-{months[-1][1]:02d}"
+          + ("  [APPLY]" if apply_writes else "  [DRY-RUN]"), flush=True)
+    agg = {"months": len(months), "family_docs": 0, "scopus_only": 0,
+           "matched_rows": 0, "unmatched": 0, "per_month": []}
+    for k, (y, m) in enumerate(months):
+        aft, bef = month_window(y, m)
+        print(f"\n########## {y}-{m:02d}  ({k + 1}/{len(months)}) ##########", flush=True)
+        s = run(aft, bef, apply_writes=apply_writes, afid_list=afid_list,
+                recheck=apply_writes and k == len(months) - 1, idx=idx)
+        for key in ("family_docs", "scopus_only", "matched_rows", "unmatched"):
+            agg[key] += s[key]
+        agg["per_month"].append({"month": f"{y}-{m:02d}", "scopus_only": s["scopus_only"],
+                                 "matched_rows": s["matched_rows"]})
+    return agg
+
+
+# ---- self-test (offline: no network / DB) -----------------------------------
+def _selftest():
+    ok = True
+
+    def check(label, cond):
+        nonlocal ok
+        ok &= bool(cond)
+        print(f"  [{'OK' if cond else '** FAIL'}] {label}")
+
+    check("numeric scopus id strips '2-s2.0-' prefix",
+          _numeric_scopus_id("2-s2.0-105037523511") == "105037523511")
+    check("container doi derived from book chapter",
+          _container_doi("10.1201/9781003735878-24", "Book Chapter") == "10.1201/9781003735878")
+    check("container doi is None for an article",
+          _container_doi("10.1007/s11940-026-00868-8", "Article") is None)
+    check("119027669 (UCSF) excluded from family set",
+          "119027669" not in load_family_afids())
+    check("rolling window spans [today-90d, today-14d]",
+          rolling_window(date(2026, 7, 4)) == ("20260405", "20260620"))
+    check("rolling window honours custom lag/span",
+          rolling_window(date(2026, 7, 4), lag_days=7, span_days=30) == ("20260604", "20260627"))
+    check("recurring window is month M-2",
+          recurring_month(date(2026, 7, 3)) == (2026, 5)
+          and recurring_month(date(2026, 1, 15)) == (2025, 11))
+    check("month_window brackets the calendar month exclusively",
+          month_window(2026, 5) == ("20260430", "20260601"))
+    check("month_range wraps the year boundary",
+          month_range((2025, 11), (2026, 2)) == [(2025, 11), (2025, 12), (2026, 1), (2026, 2)])
+    check("initial 5y backfill = 61 months, 2021-05 .. 2026-05 (M-2 boundary)",
+          initial_months(5, date(2026, 7, 3))[0] == (2021, 5)
+          and initial_months(5, date(2026, 7, 3))[-1] == (2026, 5)
+          and len(initial_months(5, date(2026, 7, 3))) == 61)
+
+    family = {"60007997"}
+    entry = {
+        "eid": "2-s2.0-105037523511", "prism:doi": "10.1/x", "subtypeDescription": "Article",
+        "dc:title": "T", "prism:publicationName": "J", "prism:coverDate": "2026-05-10",
+        "affiliation": [{"afid": "60007997", "affilname": "Weill Cornell Medicine",
+                         "affiliation-city": "New York"},
+                        {"afid": "99999999", "affilname": "Other U"}],
+        "author": [
+            {"@seq": "1", "surname": "Smith", "given-name": "Jane", "initials": "J.",
+             "afid": [{"$": "60007997"}]},
+            {"@seq": "2", "surname": "Doe", "given-name": "John", "afid": [{"$": "99999999"}]},
+        ],
+    }
+    wcm = list(wcm_authorships(entry, family))
+    check("exactly one WCM authorship tagged", len(wcm) == 1)
+    i, n, au, _ = wcm[0]
+    check("WCM author is position 0 (Smith)", i == 0 and au["last"] == "Smith")
+    check("WCM affiliation resolved to family affilname",
+          any("Weill Cornell" in a for a in au["affiliations"]))
+
+    top = {"cwid": "js1", "name": "Jane Smith", "person_type": "Faculty", "dept": "Peds",
+           "confidence": 0.9, "cohort_size": 1, "given_match": "full", "affil_dept_match": False}
+    row = _build_row(entry, i, n, au, top, [top], "2026-07-03 00:00:00")
+    check("row source=scopus, pmid None", row["source"] == "scopus" and row["pmid"] is None)
+    check("row external_id = numeric Scopus id (for Accept), doi kept separately",
+          row["external_id"] == "105037523511" and row["doi"] == "10.1/x")
+    check("row author_key = scopus:{doi}:0 (DOI-first dedup)", row["author_key"] == "scopus:10.1/x:0")
+    check("row classification=absent, no FG/IO",
+          row["classification"] == "absent"
+          and row["top_fg_score"] is None and row["top_io_score"] is None)
+    check("row single_candidate=1", row["single_candidate"] == 1)
+
+    entry2 = dict(entry, **{"prism:doi": None})
+    au2 = {"last": "Smith", "fore": "Jane", "initials": "J.", "affiliations": []}
+    row2 = _build_row(entry2, 0, 1, au2, top, [top], "2026-07-03 00:00:00")
+    check("no-DOI row falls back to numeric scopus id",
+          row2["external_id"] == "105037523511"
+          and row2["author_key"] == "scopus:105037523511:0")
+
+    print("\nSELFTEST", "PASS" if ok else "FAIL")
+    return ok
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Scopus not-in-PubMed WCM authorship detector")
+    ap.add_argument("--mode", choices=["rolling", "recurring", "initial"],
+                    help="rolling = [today-90d,today-14d] (weekly cron, Decision A); "
+                         "recurring = month M-2; initial = backfill --years back")
+    ap.add_argument("--lag-days", type=int, default=14, help="rolling mode: settle-lag before window end")
+    ap.add_argument("--span-days", type=int, default=90, help="rolling mode: window width in days")
+    ap.add_argument("--month", help="YYYY-MM single calendar month (testing / spot backfill)")
+    ap.add_argument("--from", dest="from_month", help="YYYY-MM backfill range start (with --to)")
+    ap.add_argument("--to", dest="to_month", help="YYYY-MM backfill range end (with --from)")
+    ap.add_argument("--years", type=int, default=5, help="--mode initial backfill span (default 5)")
+    ap.add_argument("--afid-list", default=DEFAULT_AFID_LIST)
+    ap.add_argument("--apply", action="store_true", help="write rows (default: dry-run)")
+    ap.add_argument("--no-recheck", action="store_true",
+                    help="skip resolving open scopus rows out (only meaningful with --apply)")
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+
+    if args.selftest:
+        sys.exit(0 if _selftest() else 1)
+    if not (SCOPUS_KEY and SCOPUS_TOKEN):
+        ap.error("SCOPUS_API_KEY and SCOPUS_INST_TOKEN must be set (never printed)")
+
+    def one_month(y, m):
+        aft, bef = month_window(y, m)
+        print(f"Scopus lane: loads of {y}-{m:02d}  (ORIG-LOAD-DATE {aft}..{bef})"
+              + ("  [APPLY]" if args.apply else "  [DRY-RUN]"), flush=True)
+        return run(aft, bef, apply_writes=args.apply, afid_list=args.afid_list,
+                   recheck=not args.no_recheck)
+
+    if args.mode == "rolling":
+        aft, bef = rolling_window(lag_days=args.lag_days, span_days=args.span_days)
+        print(f"Scopus lane: rolling ORIG-LOAD-DATE {aft}..{bef}"
+              + ("  [APPLY]" if args.apply else "  [DRY-RUN]"), flush=True)
+        summary = run(aft, bef, apply_writes=args.apply, afid_list=args.afid_list,
+                      recheck=not args.no_recheck)
+    elif args.mode == "recurring":
+        summary = one_month(*recurring_month())
+    elif args.mode == "initial":
+        summary = run_backfill(initial_months(args.years), apply_writes=args.apply,
+                               afid_list=args.afid_list)
+    elif args.from_month and args.to_month:
+        f = tuple(int(x) for x in args.from_month.split("-"))
+        t = tuple(int(x) for x in args.to_month.split("-"))
+        summary = run_backfill(month_range(f, t), apply_writes=args.apply, afid_list=args.afid_list)
+    elif args.month:
+        summary = one_month(*(int(x) for x in args.month.split("-")))
+    else:
+        ap.error("provide --mode rolling|recurring|initial, --month YYYY-MM, "
+                 "--from/--to YYYY-MM, or --selftest")
+
+    print("\n==== SCOPUS RUN SUMMARY ====")
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/update/identity_index.py
+++ b/update/identity_index.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Identity index for the Adversarial Attribution Review lanes.
+
+In-memory index of reciterdb `identity` keyed by normalised surname, plus the
+name-normalisation helpers and the person-type precedence table that both the
+PubMed matcher (`aar_matcher`) and the Scopus detector (`aar_universe_scopus`)
+share. Extracted from `aar_matcher.py` so the Scopus lane can reuse the roster
+WITHOUT dragging in the matcher's S3 / pinned-model dependencies — which lets the
+detector run in-cluster (reciterdb CronJob) with only sqlalchemy + PyMySQL.
+
+Behaviour-preserving: the class, helpers, and person-type table are verbatim the
+ones `aar_matcher` used before the extraction.
+
+Env: DB_USERNAME/DB_PASSWORD/DB_HOST/DB_NAME (reciterdb, read-only).
+"""
+import os, unicodedata
+
+from sqlalchemy import create_engine, text
+
+# person-type flags in reporting precedence order (mirrors the pubs skill CASE,
+# extended with the columns that table actually carries). label + historical flag.
+PERSON_TYPES = [
+    ("fullTimeFaculty", "Full-Time Faculty", False),
+    ("partTimeFaculty", "Part-Time Faculty", False),
+    ("voluntaryFaculty", "Voluntary Faculty", False),
+    ("adjunctFaculty", "Adjunct Faculty", False),
+    ("emeritusFaculty", "Emeritus Faculty", True),
+    ("inactiveFaculty", "Inactive Faculty", True),
+    ("faculty", "Faculty", False),
+    ("postdoc", "Postdoc", False),
+    ("fellow", "Fellow", False),
+    ("nonFaculty", "Non-Faculty", False),
+    ("residentNYP", "Resident (NYP)", False),
+    ("studentMDNYC", "Student MD (NYC)", False),
+    ("studentMDPhD", "Student MD-PhD", False),
+    ("studentMDQatar", "Student MD (Qatar)", False),
+    ("studentPhDTriI", "Student PhD (Tri-I)", False),
+    ("studentPhDWeill", "Student PhD (Weill)", False),
+    ("inactiveNonAlumniStudent", "Inactive Student", True),
+    ("alumniMD", "Alumni MD", True),
+    ("alumniMDPHD", "Alumni MD-PhD", True),
+    ("alumniPHD", "Alumni PhD", True),
+    ("alumniResidentNYP", "Alumni Resident (NYP)", True),
+]
+_PTYPE_COLS = [c for c, _, _ in PERSON_TYPES]
+
+
+# ---- normalisation ---------------------------------------------------------
+def _norm(s):
+    """Lowercase, strip accents, keep [a-z0-9] only. 'O’Brien'->'obrien'."""
+    if not s:
+        return ""
+    s = unicodedata.normalize("NFKD", str(s))
+    s = "".join(ch for ch in s if not unicodedata.combining(ch))
+    return "".join(ch for ch in s.lower() if ch.isalnum())
+
+
+def _first_initial(fore, initials):
+    """Author's first-name initial from ForeName, falling back to Initials."""
+    for src in (fore, initials):
+        n = _norm(src)
+        if n:
+            return n[0]
+    return ""
+
+
+# ---- identity index --------------------------------------------------------
+class IdentityIndex:
+    """In-memory index of reciterdb `identity`, keyed by normalised surname."""
+
+    def __init__(self, records):
+        self.by_surname = {}
+        for r in records:
+            self.by_surname.setdefault(r["surname_norm"], []).append(r)
+
+    @classmethod
+    def load(cls):
+        eng = create_engine(
+            f"mysql+pymysql://{os.environ['DB_USERNAME']}:{os.environ['DB_PASSWORD']}"
+            f"@{os.environ['DB_HOST']}/{os.environ['DB_NAME']}",
+            connect_args={"connect_timeout": 15}, pool_pre_ping=True)
+        cols = ("cwid, givenName, middleName, surname, primaryAcademicDepartment, "
+                "primaryAcademicDivision, primaryTitle, primaryProgram, "
+                + ", ".join(_PTYPE_COLS))
+        with eng.connect() as c:
+            rows = c.execute(text(
+                f"SELECT {cols} FROM identity "
+                "WHERE surname IS NOT NULL AND surname <> ''")).mappings().all()
+        return cls([cls._record(r) for r in rows])
+
+    @staticmethod
+    def _record(r):
+        ptype, historical = "Other / CTSC", False
+        for col, label, hist in PERSON_TYPES:
+            if str(r[col]).lower() == "yes":
+                ptype, historical = label, hist
+                break
+        given = r["givenName"] or ""
+        return {
+            "cwid": r["cwid"],
+            "given": given, "middle": r["middleName"] or "", "surname": r["surname"] or "",
+            "given_norm": _norm(given), "surname_norm": _norm(r["surname"]),
+            "dept": r["primaryAcademicDepartment"] or "",
+            "division": r["primaryAcademicDivision"] or "",
+            "program": r["primaryProgram"] or "",
+            "title": r["primaryTitle"] or "",
+            "person_type": ptype, "historical": historical,
+        }
+
+    def candidates(self, last, fore=None, initials=None, affiliations=None, top_k=5):
+        """Ranked candidate CWIDs for one authorship (no identity-only score yet).
+
+        Returns (candidates, cohort_size). cohort_size is the full homonym count
+        (surname + initial) the curator faces, even if the list is capped at top_k."""
+        surname_norm = _norm(last)
+        if not surname_norm:
+            return [], 0
+        pool = self.by_surname.get(surname_norm, [])
+        if not pool:
+            return [], 0
+        author_init = _first_initial(fore, initials)
+        author_given = _norm(fore)
+        affil_blob = " ".join(_norm(a) for a in (affiliations or []))
+
+        cohort = []
+        for rec in pool:
+            if author_init and rec["given_norm"]:
+                if rec["given_norm"][0] != author_init:
+                    continue                       # initial mismatch -> not this person
+                given_match = ("full" if author_given and rec["given_norm"] == author_given
+                               else "initial")
+            else:
+                given_match = "unknown"            # no usable given on either side
+            cohort.append((rec, given_match))
+
+        cohort_size = len(cohort)
+        out = []
+        for rec, given_match in cohort:
+            affil_match, where = self._affil_match(rec, affil_blob)
+            out.append({
+                "cwid": rec["cwid"],
+                "name": " ".join(x for x in (rec["given"], rec["middle"], rec["surname"]) if x),
+                "dept": rec["dept"], "division": rec["division"],
+                "person_type": rec["person_type"], "title": rec["title"],
+                "given_match": given_match,
+                "affil_dept_match": affil_match, "affil_match_on": where,
+                "cohort_size": cohort_size,
+                "confidence": self._confidence(given_match, cohort_size, affil_match,
+                                               rec["historical"]),
+            })
+        out.sort(key=lambda d: (d["given_match"] == "full", d["affil_dept_match"],
+                                d["confidence"]), reverse=True)
+        return out[:top_k], cohort_size
+
+    @staticmethod
+    def _affil_match(rec, affil_blob):
+        """Does the affiliation text name the candidate's dept or division?"""
+        if not affil_blob:
+            return False, None
+        dept_n = _norm(rec["dept"])
+        if dept_n and len(dept_n) >= 4 and dept_n in affil_blob:
+            return True, "dept"
+        # division: any distinctive word (>=5 chars) present in the affiliation
+        for word in (rec["division"] or "").replace("&", " ").replace(",", " ").split():
+            w = _norm(word)
+            if len(w) >= 5 and w in affil_blob:
+                return True, "division"
+        return False, None
+
+    @staticmethod
+    def _confidence(given_match, cohort_size, affil_match, historical):
+        base = 0.50 if given_match == "full" else 0.25 if given_match == "initial" else 0.15
+        rarity = 0.40 / max(cohort_size, 1)
+        affil = 0.25 if affil_match else 0.0
+        hist = -0.10 if historical else 0.0
+        return round(max(0.0, min(1.0, base + rarity + affil + hist)), 3)

--- a/update/run_all.py
+++ b/update/run_all.py
@@ -107,6 +107,28 @@ def upload_log_to_s3():
         logger.error("Failed to upload logs to S3")
         logger.exception(e)
 
+# ------------- AAR Scopus lane (weekly, isolated) -------------
+def run_scopus_lane_if_due():
+    """Weekly Scopus not-in-PubMed authorship detector (AAR / PM#775).
+
+    Fully isolated from the reporting rebuild: gated to Sundays, skipped if its API
+    keys are absent, and any failure is caught and logged so it can NEVER fail the
+    nightly job. A pre-migration DB (missing authorship_review columns) surfaces here
+    as a swallowed script failure, not a pipeline abort."""
+    try:
+        import datetime as _datetime
+        if _datetime.datetime.utcnow().weekday() != 6:   # 6 = Sunday
+            logger.info("Scopus lane: not due (runs weekly on Sundays) — skipped")
+            return
+        if not (os.getenv("SCOPUS_API_KEY") and os.getenv("SCOPUS_INST_TOKEN")):
+            logger.warning("Scopus lane: SCOPUS_API_KEY/INST_TOKEN unset — skipped")
+            return
+        run_script("aarScopusLane", "python3 aar_universe_scopus.py --mode rolling --apply",
+                   timeout_seconds=int(os.getenv("SCOPUS_TIMEOUT_SECONDS", "3600")))
+    except Exception as e:
+        logger.exception(f"Scopus lane failed (ignored — reporting unaffected): {e}")
+
+
 # ------------- Main Flow -------------
 def main():
     scripts = [
@@ -128,6 +150,10 @@ def main():
             overall_success = False
             logger.error("Stopping pipeline due to script failure.")
             break
+
+    # AAR Scopus lane — runs only if the reporting rebuild succeeded, weekly, isolated.
+    if overall_success:
+        run_scopus_lane_if_due()
 
     upload_log_to_s3()
 

--- a/update/scopus_afids.csv
+++ b/update/scopus_afids.csv
@@ -1,0 +1,135 @@
+afid,name,origin
+60007997,Weill Cornell Medicine,home-list
+105529809,Weill Cornell,home-list
+108567977,Weill Cornell,home-list
+60019868,Weill Cornell Medical Center,home-list
+60000247,Weill Cornell Graduate School of Medical Sciences,home-list
+60072750,Weill Cornell Medicine-Qatar,home-list
+60109878,Weill Cornell Medicine Feil Family Brain & Mind Research Institute,home-list
+60026978,Weill Cornell Institute of Geriatric Psychiatry,home-list
+60025849,Weill Cornell Breast Center,home-list
+100315705,Division of Cardiology,home-list
+100370280,Division of Endocrinology,home-list
+115325844,Center for Autism and the Developing Brain,home-list
+107923633,New York Weill Cornell Center,home-list
+112568533,NewYork-Presbyterian/Weill Cornell,home-list
+117155719,Samuel J. Wood Library and C.V. Starr Biomedical Information Center,home-list
+118363394,Weill Cornell,home-list
+109378892,Weill Cornell,home-list
+118197089,Weill Cornell Medicine,home-list
+120163969,Weill Cornell Department of Medicine,home-list
+112627712,Weill Cornell,home-list
+114308448,Tri-Institutional Therapeutics Discovery Institute,home-list
+101996631,Cornell-Weill Medical Program,home-list
+122917640,Tri-Institutional Therapeutics Discovery Institute,home-list
+108960262,Weill Cornell,home-list
+126598090,Weill Cornell Cardiovascular Outcomes Research Group (CORG),home-list
+126569819,Weill Cornell Medicine,home-list
+126209228,Weill Cornell Medicine and NewYork-Presbyterian,home-list
+112743895,Weill Cornell Cancer Center,home-list
+112651838,Weill Cornell Center for Genomic Health,home-list
+124678793,Weill Cornell,home-list
+112805461,Weill Cornell Genomics Core Facility,home-list
+126291601,Weill Cornell Campus,home-list
+116739393,NewYork-Presbyterian Weill Cornell Medicine,home-list
+112625535,Weill Cornell Brain and Spine Center,home-list
+125305204,Weill Cornell,home-list
+114850318,Weill Cornell at New York–Presbyterian,home-list
+125303244,Weill Cornell,home-list
+128252749,Weill Cornell Medicine,home-list
+127074522,Weill Cornell Medicine Department of Ophthalmology,home-list
+116516911,New York Presbyterian Weill Cornell Department of Gynecologic Oncology,home-list
+113384516,Tri-Institutional Laboratory of Comparative Pathology,home-list
+101778222,Tri-Institutional PhD Program in Chemical Biology,home-list
+105184720,Tri-Institutional Training Program in Computational Biology and Medicine,home-list
+60138910,Weill Bugando School of Medicine,home-list
+125316739,Weill Cornell,home-list
+126961696,Weill Cornell Medicine,home-list
+120409098,Weill Cornell New York Presbyterian Epilepsy Center,home-list
+100520080,Columbia Weill Cornell Division of Vascular Surgery,home-list
+101633292,New York Presbyterian Weill Cornell Hospital,home-list
+123730906,Tri-Institutional MD-PhD Program,home-list
+106537581,Weill Medicine,home-list
+113207685,Weill Cornell High School Science Immersion Program,home-list
+107163477,Institute for Geriatric Psychiatry,home-list
+60012732,Weill Cornell Internal Medicine Associates,home-list
+126269126,Weill Cornell Medicine,home-list
+127863145,Weill Cornell Medicine,home-list
+122033412,Weill Cornell Medicine Center for Perioperative Outcomes,home-list
+108364787,Weill Cornell Medicine Center,home-list
+105800915,Weill Cornell Multiple Sclerosis Center,home-list
+130869980,Weill Cornell Graduate School,affil-search-added
+119027669,Weill Institute for Neurosciences,affil-search-added
+126208284,Weill Cornell Physician Organization,affil-search-added
+132711035,Weill-Cornell Tri-Institutional Pain Program,affil-search-added
+128656280,Weill Cornell Neuroscience PhD Program,affil-search-added
+106657695,New York Weill Medical Center,affil-search-added
+121839777,Komansky Children's Hospital/Weill Cornell,affil-search-added
+122425735,Weill Cornell Physician Organization Information Services,affil-search-added
+113394884,Weill Bugando Hospital,affil-search-added
+129668484,Weill Cornell Physicians Organization,affil-search-added
+125631686,Weill Cornel Medicine University,affil-search-added
+105937601,Weill Greenberg Center,affil-search-added
+101651661,NYPH Weill Cornell,affil-search-added
+129586939,NewYork-Presbyterian Weill Cornell Psychiatry,affil-search-added
+112620368,Weill Cornell Department of Anesthesiology,affil-search-added
+126626355,Weill Cornel Medicine,affil-search-added
+106204585,Laboratoire de Biochimie (Dr. Pr. J. Weill) U.E.R. Médecine-2 bis,affil-search-added
+107061575,Weill-Cornell Cellular Immunology Laboratory,affil-search-added
+131493557,Weill Cornell Division of Biostatistics,affil-search-added
+133842299,Weill Cornell Medicine-Qatar,affil-search-added
+131589519,Ｗｅｉｌｌ Ｃｏｒｎｅｌｌ Ｍｅｄｉｃａｌ Ｃｏｌｌｅｇｅ,affil-search-added
+133465780,Weill Cornell Department of Urology Center for Female Pelvic Health,affil-search-added
+116516732,New York Presbyterian Weill Cornell Department of Pathology,affil-search-added
+132841731,Weill Cornel College of Medicine,affil-search-added
+132445283,Pediatrics and Neurology Weill Cornell Medicine Pediatric Headache Program,affil-search-added
+128079802,Weill Bu-gando School of Medicine,affil-search-added
+119877568,NY Presbyt. H.-Weill Cor. Med. Ctr.,affil-search-added
+107633220,Weill Bugando Medical University,affil-search-added
+122252381,Weill Institute for Neurosciences and,affil-search-added
+131674732,Sidra/Weill Cornell Medicine,affil-search-added
+130838894,Weill Cornell Medicine,affil-search-added
+131129088,Weill Cornell Medicine Brain and Spine Center/NewYork-Presbyterian Lower Manhattan Hospital,affil-search-added
+132872473,Weill Cornell Medicine,affil-search-added
+116238048,Weill Cornell Center for Human Rights,affil-search-added
+117521746,Cornell Weill University Emily Grover,affil-search-added
+132684862,First Databank/ Weill Cornell,affil-search-added
+116202584,Weill Bugando School of Medicine,affil-search-added
+132915840,Weill Cornell Medicine for the Alzheimer’s Disease Neuroimaging Initiative,affil-search-added
+114543725,Personality Disorders Institute of Weill-Cornell,affil-search-added
+109542000,Weill Cornell Parkinson's Disease and Movement Disorders Institute,affil-search-added
+132922057,Weill Cornell University Medical College,affil-search-added
+130937596,Weill Cornell Memory Disorders Program,affil-search-added
+134196764,Weill,affil-search-added
+133614850,Meyer Cancer Center Weill Cornell Medicine,affil-search-added
+132184594,Platelet Research & Treatment Program Weill,affil-search-added
+100932112,Henrietta Weill Memorial Child Guidance Clinic,affil-search-added
+122812895,New York Presbyterian Hospital/ Weill Cornell Medicine,affil-search-added
+125800957,Weill Cornell Physicians,affil-search-added
+133394180,Weill Medical College of Cornell University-Qatar,affil-search-added
+112942526,Weill Bugando Medical College,affil-search-added
+122523690,Weill Cornell Medicine,affil-search-added
+128998395,Weill Neurosciences Institute and Department of Neurology,affil-search-added
+131230352,Weill Cornell Department Rehabilitation Medicine,affil-search-added
+115068614,Dalio Institute of Cardiovascular Imaging NewYork-Presbyterian Hospital and Weill Cornell Medical College,affil-search-added
+132424599,Weill Cornell Grаduаte School of Medicаl Sciences,affil-search-added
+131489462,Weill Cornel Medicine,affil-search-added
+127433001,Weill Cornell Medicine Department of Otolaryngology-Head and Neck Surgery,affil-search-added
+129587781,NewYork-Presbyterian,affil-search-added
+134124686,Cardiovascular Research Institute (J.C.L.) Weill Cornell Medicine,affil-search-added
+125580277,Weill Cornell,affil-search-added
+126256894,Samuel J. Wood Library Weill CornellMedicine,affil-search-added
+124679109,Weill Medical College,affil-search-added
+126644991,New York-Presbyterian Hospital Weill,affil-search-added
+132575451,Weill Corneal Medical Hospital,affil-search-added
+112804547,Hôpital Simone Weill,affil-search-added
+101772812,Weill Medical Collegea,affil-search-added
+133777607,The John Milton McLean Professor and Chair Weill Cornell Medicine Ophthalmology,affil-search-added
+129663339,Medicine Weill Cornell SOM NYPresbyterian-BMH,affil-search-added
+124165793,Weill Cornell Medical College/NYP Hospital,affil-search-added
+131282391,Weill Cornell Medical College,affil-search-added
+133651082,Weill Cornell Medical College,affil-search-added
+112599633,Weill Bugando Medical College of Health Sciences,affil-search-added
+129271093,Sidra/Weill Cornell Medicine,affil-search-added
+115301677,Weill Comrnell Medical Center,affil-search-added
+127295815,Well Cornell University Hospital,affil-search-added


### PR DESCRIPTION
## What

Promotes ReCiterDB #105 (AAR Scopus lane in-cluster) to `master`, so the
Scopus not-in-PubMed WCM authorship detector runs in the prod `reciterdb`
CronJob instead of the monthly Mac cron. Surgical `-master` counterpart of the
dev merge #105 (same pattern as #99↔#100), so **only** the Scopus lane ships to
prod — not the other 33 dev-only commits.

Two commits:
1. **v1.6 multi-source schema** (folded in — was orphaned, never merged to dev or
   master): updates the canonical `setup/table_authorship_review.sql` and adds the
   idempotent `alter_authorship_review_multisource_v1.6.sql`. Master's canonical DDL
   was still PubMed-only; this makes fresh builds correct.
2. **#105 code** (`94642d8`): vendors `aar_universe_scopus.py`, `aar_db.py`,
   `identity_index.py`, `scopus_afids.csv` into `update/`; appends a Sunday-gated,
   keys-gated, try/except-wrapped Scopus step to `run_all.py` (cannot fail the
   nightly reporting rebuild); adds `SCOPUS_API_KEY`/`SCOPUS_INST_TOKEN`/`PUBMED_API_KEY`
   env refs to the CronJob (secrets already in the namespace).

## Prod DB already migrated (verified)

The prod producer `reciterdb` was **already** at v1.6 — a one-off idempotent apply
against it was a no-op (every guarded ALTER reported "already exists"), and the
table already holds 212 `source=scopus` rows (from the Mac cron) + 15,992 `pubmed`.
So the folded schema commit is repo-hygiene, not a functional prerequisite; the
in-cluster lane upserts into the same already-correct table.

## After merge (deploy — separate step)

1. ReCiterDB CodeBuild builds a new `master-2xx` image.
2. Bump the CronJob image tag in `kubernetes/k8-cronjob.yaml` + `kubectl apply`
   (also lands the new env refs).
3. One-off Job from the new image: `python3 aar_universe_scopus.py --mode recurring --apply`
   to confirm rows land with `source=scopus` (bypasses the Sunday gate).
4. Retire the Mac `aar_cron_recurring.sh` Scopus block to stop double-writing.

Cadence stays weekly-Sunday (rolling 90/14-day window, idempotent upserts).

## Follow-up

The v1.6 schema files are still missing from the **dev** repo tree (dev's DB has
the migration applied, but the tree doesn't record it). A matching dev PR for
`7add5c6` would close that gap.
