### PR TITLE
fix(importer): tolerate NULL evidence blocks so articles aren't dropped

### DIFF
--- a/update/dataTransformer.py
+++ b/update/dataTransformer.py
@@ -268,13 +268,17 @@ def process_person_article(items, output_path):
                         journal_title_verbose = sanitize_field(article.get('journalTitleVerbose', ''))
                         article_title = sanitize_field(article.get('articleTitle', ''))
 
-                        # Evidence fields
-                        evidence = article.get('evidence', {})
+                        # Evidence fields. DynamoDBMapper serializes an absent
+                        # @DynamoDBDocument evidence block as a NULL attribute, so
+                        # .get(key, {}) can return None (not {}); use `or {}` / `or []`
+                        # so a null block coerces to empty instead of raising
+                        # AttributeError and silently dropping the whole article.
+                        evidence = article.get('evidence') or {}
 
                         # Author name evidence
-                        author_name_evidence = evidence.get('authorNameEvidence', {})
-                        article_author_name = author_name_evidence.get('articleAuthorName', {})
-                        institutional_author_name = author_name_evidence.get('institutionalAuthorName', {})
+                        author_name_evidence = evidence.get('authorNameEvidence') or {}
+                        article_author_name = author_name_evidence.get('articleAuthorName') or {}
+                        institutional_author_name = author_name_evidence.get('institutionalAuthorName') or {}
                         article_author_first_name = sanitize_field(article_author_name.get('firstName', ''))
                         article_author_last_name = sanitize_field(article_author_name.get('lastName', ''))
                         institutional_author_first_name = sanitize_field(institutional_author_name.get('firstName', ''))
@@ -294,19 +298,19 @@ def process_person_article(items, output_path):
                         target_author_count_penalty = sanitize_field(evidence.get('targetAuthorCountPenalty', ''))
                         
                         # Email evidence
-                        email_evidence = evidence.get('emailEvidence', {})
+                        email_evidence = evidence.get('emailEvidence') or {}
                         email_match = sanitize_field(email_evidence.get('emailMatch', ''))
                         email_match_score = sanitize_field(email_evidence.get('emailMatchScore', ''))
 
                         # Journal subfield evidence
-                        journal_subfield_evidence = evidence.get('journalCategoryEvidence', {})
+                        journal_subfield_evidence = evidence.get('journalCategoryEvidence') or {}
                         journal_subfield_label = sanitize_field(journal_subfield_evidence.get('journalSubfieldScienceMetrixLabel', ''))
                         journal_subfield_id = sanitize_field(journal_subfield_evidence.get('journalSubfieldScienceMetrixID', ''))
                         journal_subfield_department = sanitize_field(journal_subfield_evidence.get('journalSubfieldDepartment', ''))
                         journal_subfield_score = sanitize_field(journal_subfield_evidence.get('journalSubfieldScore', ''))
 
                         # Relationship evidence
-                        relationship_evidence = evidence.get('relationshipEvidence', {})
+                        relationship_evidence = evidence.get('relationshipEvidence') or {}
                         relationship_total_score = sanitize_field(relationship_evidence.get('relationshipEvidenceTotalScore', ''))
 
                         relationship_positive_match_score = sanitize_field(
@@ -331,7 +335,7 @@ def process_person_article(items, output_path):
                             relationship_non_match_score = ''
 
                         # Education year evidence
-                        education_year_evidence = evidence.get('educationYearEvidence', {})
+                        education_year_evidence = evidence.get('educationYearEvidence') or {}
                         article_year = sanitize_field(education_year_evidence.get('articleYear', ''))
                         identity_bachelor_year = sanitize_field(education_year_evidence.get('identityBachelorYear', ''))
                         discrepancy_degree_year_bachelor = sanitize_field(education_year_evidence.get('discrepancyDegreeYearBachelor', ''))
@@ -341,28 +345,28 @@ def process_person_article(items, output_path):
                         discrepancy_degree_year_doctoral_score = sanitize_field(education_year_evidence.get('discrepancyDegreeYearDoctoralScore', ''))
 
                         # Gender evidence
-                        gender_evidence = evidence.get('genderEvidence', {})
+                        gender_evidence = evidence.get('genderEvidence') or {}
                         gender_score_article = sanitize_field(gender_evidence.get('genderScoreArticle', ''))
                         gender_score_identity = sanitize_field(gender_evidence.get('genderScoreIdentity', ''))
                         gender_score_identity_article_discrepancy = sanitize_field(gender_evidence.get('genderScoreIdentityArticleDiscrepancy', ''))
 
                         # Person type evidence
-                        person_type_evidence = evidence.get('personTypeEvidence', {})
+                        person_type_evidence = evidence.get('personTypeEvidence') or {}
                         person_type = sanitize_field(person_type_evidence.get('personType', ''))
                         person_type_score = sanitize_field(person_type_evidence.get('personTypeScore', ''))
 
                         # Article count evidence
-                        article_count_evidence = evidence.get('articleCountEvidence', {})
+                        article_count_evidence = evidence.get('articleCountEvidence') or {}
                         count_articles_retrieved = sanitize_field(article_count_evidence.get('countArticlesRetrieved', ''))
                         article_count_score = sanitize_field(article_count_evidence.get('articleCountScore', ''))
 
                         # Author count evidence
-                        author_count_evidence = evidence.get('authorCountEvidence', {})
+                        author_count_evidence = evidence.get('authorCountEvidence') or {}
                         count_authors = sanitize_field(author_count_evidence.get('countAuthors', ''))
                         author_count_score = sanitize_field(author_count_evidence.get('authorCountScore', ''))
 
                         # PubMed affiliation evidence
-                        affiliation_evidence = evidence.get('affiliationEvidence', {})
+                        affiliation_evidence = evidence.get('affiliationEvidence') or {}
                         pubmed_target_author_affiliation = affiliation_evidence.get('pubmedTargetAuthorAffiliation', {})
                         if isinstance(pubmed_target_author_affiliation, dict):
                             target_author_institutional_affiliation_article_pubmed_label = sanitize_field(
@@ -654,7 +658,7 @@ def process_person_article_department(items, output_path):
                     pmid = article.get('pmid', 0)
 
                     # Extract organizational unit evidence
-                    org_units = article.get('evidence', {}).get('organizationalUnitEvidence', [])
+                    org_units = (article.get('evidence') or {}).get('organizationalUnitEvidence') or []
                     for org_unit in org_units:
                         rows.append([
                             person_identifier,
@@ -703,7 +707,7 @@ def process_person_article_grant(items, output_path):
                     pmid = article.get('pmid', 0)  # PMIDs are typically integers
 
                     # Extract grant evidence
-                    grant_evidence = article.get('evidence', {}).get('grantEvidence', {})
+                    grant_evidence = (article.get('evidence') or {}).get('grantEvidence') or {}
                     grants = grant_evidence.get('grants', [])
 
                     for grant in grants:
@@ -809,7 +813,7 @@ def process_person_article_relationship(items, output_path):
             try:
                 for article in item.get('reCiterArticleFeatures', []):
                     pmid = article.get('pmid', 0)
-                    relationship_evidence = article.get('evidence', {}).get('relationshipEvidence', {})
+                    relationship_evidence = (article.get('evidence') or {}).get('relationshipEvidence') or {}
 
                     if relationship_evidence:
                         # Process 'relationshipPositiveMatch' if it exists
@@ -888,7 +892,7 @@ def process_person_article_scopus_non_target_author_affiliation(items, output_pa
                         pmid = sanitize_field(article.get('pmid', 0))  # PMIDs are typically integers
 
                         # Extract affiliation evidence
-                        affiliation_evidence = article.get('evidence', {}).get('affiliationEvidence', {})
+                        affiliation_evidence = (article.get('evidence') or {}).get('affiliationEvidence') or {}
                         scopus_non_target_affiliations = affiliation_evidence.get(
                             'scopusNonTargetAuthorAffiliation', {}
                         )
@@ -984,9 +988,9 @@ def process_person_article_scopus_target_author_affiliation(items, output_path):
 
                 # Extract Scopus target affiliation evidence
                 scopus_target_affiliations = (
-                    article.get('evidence', {})
-                          .get('affiliationEvidence', {})
-                          .get('scopusTargetAuthorAffiliation', [])
+                    ((article.get('evidence') or {})
+                          .get('affiliationEvidence') or {})
+                          .get('scopusTargetAuthorAffiliation') or []
                 )
 
                 for affiliation in scopus_target_affiliations:

--- a/update/test_null_evidence.py
+++ b/update/test_null_evidence.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Regression test: articles with NULL evidence blocks must not be dropped.
+
+DynamoDBMapper serializes an absent @DynamoDBDocument evidence block as a NULL
+attribute, so the DynamoDB->CSV transform sees evidence sub-objects as None
+instead of {}. Before the `or {}` fix, chained `.get()` raised AttributeError
+and the per-article try/except silently dropped the whole article -- e.g. ccole
+lost 46 of 47 articles, leaving 0 ACCEPTED in person_article.
+
+Run: python3 test_null_evidence.py
+"""
+import csv, os, tempfile
+from dataTransformer import process_person_article
+
+
+def _rows(record):
+    with tempfile.TemporaryDirectory() as d:
+        process_person_article([record], d + "/")
+        with open(os.path.join(d, "person_article2.csv")) as f:
+            return list(csv.DictReader(f))
+
+
+def test_null_evidence_blocks_do_not_drop_article():
+    # Every evidence sub-block that we observed as NULL in prod, plus a null
+    # sub-sub-object (authorNameEvidence.articleAuthorName).
+    record = {
+        "personIdentifier": "test0001",
+        "reCiterArticleFeatures": [{
+            "pmid": 12345678,
+            "userAssertion": "ACCEPTED",
+            "evidence": {
+                "emailEvidence": None,
+                "journalCategoryEvidence": None,
+                "genderEvidence": None,
+                "relationshipEvidence": None,
+                "authorNameEvidence": {"articleAuthorName": None,
+                                       "institutionalAuthorName": None},
+            },
+        }],
+    }
+    rows = _rows(record)
+    assert len(rows) == 1, f"article dropped: expected 1 row, got {len(rows)}"
+    assert rows[0]["userAssertion"] == "ACCEPTED"
+
+
+def test_evidence_itself_null_does_not_crash():
+    record = {
+        "personIdentifier": "test0002",
+        "reCiterArticleFeatures": [{"pmid": 99, "userAssertion": "REJECTED",
+                                    "evidence": None}],
+    }
+    rows = _rows(record)
+    assert len(rows) == 1, f"article dropped when evidence is None: got {len(rows)}"
+
+
+if __name__ == "__main__":
+    test_null_evidence_blocks_do_not_drop_article()
+    test_evidence_itself_null_does_not_crash()
+    print("OK: null evidence blocks no longer drop articles")


### PR DESCRIPTION
## Problem

The nightly reciterdb importer silently dropped the majority of some people's articles from `person_article`, so they never reached `analysis_summary_author` / `analysis_summary_person`.

`update/dataTransformer.py` read nested evidence blocks with `evidence.get(key, {})`. That default only fires when the key is **absent** — when the attribute is **present-but-null**, `.get()` returns `None`, and the chained `.get()` raises `'NoneType' object has no attribute 'get'`. The per-article `try/except` then skips the entire article.

ReCiter's DynamoDBMapper serializes an absent `@DynamoDBDocument` evidence block (e.g. `emailEvidence` when there is no email match) as a DynamoDB `NULL` attribute. So any article missing one of these blocks — the common case — was dropped.

### Observed impact
| uid | articles in DynamoDB | loaded before | loaded after |
|-----|----|----|----|
| ccole | 47 | **1** (0 ACCEPTED, the sole survivor a false-positive w/ an email match) | 47 (32 ACCEPTED) |
| paa2013 | 59 | **3** (1 ACCEPTED) | 59 (11 ACCEPTED) |

Currently 9 records carry null evidence blocks (all recently re-scored on the Corretto17 build). It is latent for everyone else: the same serialization reaching the prod inst-client run would gut `person_article` system-wide.

## Fix

Coerce present-but-null evidence blocks to empty (`or {}` / `or []`) at every nested evidence access — in `process_person_article` and the author/department/grant/relationship/scopus-affiliation transforms. `null` is valid JSON meaning "no evidence"; the importer now treats it identically to an absent block, independent of which producer/SDK wrote the record.

## Test

`update/test_null_evidence.py` — builds records with null evidence sub-blocks (and a fully-null `evidence`) and asserts the article is not dropped. Fails on the pre-fix code (0 rows), passes after.

Verified against live DynamoDB records (ccole, paa2013) as above.

## Note (separate, upstream)

Root trigger is a serialization regression: the Corretto17 ReCiter build writes null `@DynamoDBDocument` fields as `NULL` where the old JDK11 build omitted them. Tracked separately in ReCiter — this importer fix is the durable, producer-agnostic guard and does not depend on the upstream change.