### PR TITLE
feat(reporting): promote external_article ETL to master (#101/#110)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY update/abstractImport.py ./
 COPY update/conflictsImport.py ./
 COPY update/dataTransformer.py ./
 COPY update/executeFeatureGenerator.py ./
+COPY update/retrieveExternalArticles.py ./
 COPY update/run_all.py ./
 
 # AAR Scopus lane (not-in-PubMed WCM authorship detector — weekly, gated in run_all.py)

--- a/setup/table_external_article.sql
+++ b/setup/table_external_article.sql
@@ -1,0 +1,37 @@
+-- =============================================================================
+-- external_article — reporting projection of the ExternalArticle DynamoDB table
+-- =============================================================================
+-- Manually-added non-PubMed publications (Publication Manager "Add publication" ->
+-- OpenAlex / Scopus, ReCiter #661/#662). This MySQL table is a pure PROJECTION of the
+-- DynamoDB `ExternalArticle` table, refreshed by update/retrieveExternalArticles.py
+-- (truncate + reload each nightly run) so external pubs surface in reciterdb reporting
+-- (ReCiterDB #101).
+--
+-- Unlike `authorship_review` (durable curator state), this is a rebuildable projection:
+-- the source of truth is DynamoDB, so it IS truncated + reloaded nightly.
+--
+-- `suppressed` rows (a Scopus/OpenAlex record later superseded by its PubMed twin, same
+-- DOI) are KEPT here with the flag so reporting can include or exclude them; exclude
+-- them from person publication counts to avoid double-counting the PubMed version.
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `external_article` (
+  `uid`                 VARCHAR(64)  NOT NULL,
+  `article_id`          VARCHAR(96)  NOT NULL,            -- SCOPUS:/OPENALEX:/WOS:<id>
+  `source_type`         ENUM('SCOPUS','WOS','OPENALEX') NOT NULL,
+  `doi`                 VARCHAR(255) NULL,
+  `pmid`                BIGINT       NULL,                -- normally absent; blocked at add time
+  `title`               TEXT         NULL,
+  `journal_or_venue`    VARCHAR(512) NULL,
+  `authors`             TEXT         NULL,                -- JSON array (source-provided)
+  `pub_date`            VARCHAR(32)  NULL,                -- source-provided (yyyy or yyyy-MM-dd)
+  `publication_type`    VARCHAR(64)  NULL,
+  `added_by`            VARCHAR(64)  NULL,
+  `date_added`          VARCHAR(32)  NULL,
+  `method`              VARCHAR(64)  NULL,
+  `suppressed`          TINYINT(1)   NOT NULL DEFAULT 0,
+  `superseded_by_pmid`  BIGINT       NULL,
+  PRIMARY KEY (`uid`, `article_id`),
+  KEY `ix_source` (`source_type`),
+  KEY `ix_doi` (`doi`),
+  KEY `ix_suppressed` (`suppressed`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/update/retrieveExternalArticles.py
+++ b/update/retrieveExternalArticles.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""ETL: scan the ExternalArticle DynamoDB table -> reciterdb.external_article (MySQL).
+
+Projects the manually-added external-source publications (Publication Manager
+"Add publication" -> OpenAlex / Scopus, ReCiter #661/#662) into the reporting DB so
+external pubs surface in reciterdb reporting (ReCiterDB #101).
+
+Pure projection: TRUNCATE + reload each run (source of truth is DynamoDB). Suppressed
+rows (superseded by a PubMed twin) are loaded WITH the flag so reporting can include or
+exclude them. The table is small (manually-added pubs), so a full scan + executemany is
+plenty -- no segmented/parallel scan needed.
+
+Robust: a missing or empty ExternalArticle table loads 0 rows and exits 0 (the external
+feature is not live on every env). Only a genuine MySQL/AWS error exits non-zero.
+
+Env: DB_HOST/DB_USERNAME/DB_PASSWORD/DB_NAME (reciterdb), AWS creds + AWS_DEFAULT_REGION.
+"""
+import os
+import sys
+import json
+import logging
+
+import boto3
+import pymysql
+from botocore.exceptions import ClientError
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("retrieveExternalArticles")
+
+DDB_TABLE = "ExternalArticle"
+MYSQL_TABLE = "external_article"
+
+CREATE_SQL = """
+CREATE TABLE IF NOT EXISTS `external_article` (
+  `uid`                 VARCHAR(64)  NOT NULL,
+  `article_id`          VARCHAR(96)  NOT NULL,
+  `source_type`         ENUM('SCOPUS','WOS','OPENALEX') NOT NULL,
+  `doi`                 VARCHAR(255) NULL,
+  `pmid`                BIGINT       NULL,
+  `title`               TEXT         NULL,
+  `journal_or_venue`    VARCHAR(512) NULL,
+  `authors`             TEXT         NULL,
+  `pub_date`            VARCHAR(32)  NULL,
+  `publication_type`    VARCHAR(64)  NULL,
+  `added_by`            VARCHAR(64)  NULL,
+  `date_added`          VARCHAR(32)  NULL,
+  `method`              VARCHAR(64)  NULL,
+  `suppressed`          TINYINT(1)   NOT NULL DEFAULT 0,
+  `superseded_by_pmid`  BIGINT       NULL,
+  PRIMARY KEY (`uid`, `article_id`),
+  KEY `ix_source` (`source_type`),
+  KEY `ix_doi` (`doi`),
+  KEY `ix_suppressed` (`suppressed`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+"""
+
+COLS = ["uid", "article_id", "source_type", "doi", "pmid", "title", "journal_or_venue",
+        "authors", "pub_date", "publication_type", "added_by", "date_added", "method",
+        "suppressed", "superseded_by_pmid"]
+
+
+def _conn():
+    return pymysql.connect(host=os.getenv("DB_HOST"), user=os.getenv("DB_USERNAME"),
+                           password=os.getenv("DB_PASSWORD"), db=os.getenv("DB_NAME"),
+                           charset="utf8mb4")
+
+
+def scan_external_articles():
+    """Full paginated scan of the ExternalArticle table. Missing table -> []."""
+    table = boto3.resource("dynamodb",
+                           region_name=os.getenv("AWS_DEFAULT_REGION", "us-east-1")).Table(DDB_TABLE)
+    items, kwargs = [], {}
+    try:
+        while True:
+            resp = table.scan(**kwargs)
+            items.extend(resp.get("Items", []))
+            lek = resp.get("LastEvaluatedKey")
+            if not lek:
+                break
+            kwargs["ExclusiveStartKey"] = lek
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ResourceNotFoundException":
+            logger.warning(f"{DDB_TABLE} DynamoDB table not found — loading 0 rows.")
+            return []
+        raise
+    return items
+
+
+def _to_int(v):
+    return int(v) if v is not None else None   # DynamoDB numbers arrive as Decimal
+
+
+def to_row(it):
+    authors = it.get("authors")
+    return {
+        "uid": it.get("uid"),
+        "article_id": it.get("articleId"),
+        "source_type": it.get("sourceType"),
+        "doi": it.get("doi"),
+        "pmid": _to_int(it.get("pmid")),
+        "title": it.get("title"),
+        "journal_or_venue": it.get("journalOrVenue"),
+        "authors": json.dumps(authors) if authors is not None else None,
+        "pub_date": it.get("pubDate"),
+        "publication_type": it.get("publicationType"),
+        "added_by": it.get("addedBy"),
+        "date_added": it.get("dateAdded"),
+        "method": it.get("method"),
+        "suppressed": 1 if it.get("suppressed") else 0,
+        "superseded_by_pmid": _to_int(it.get("supersededByPmid")),
+    }
+
+
+def load(rows):
+    conn = _conn()
+    try:
+        with conn.cursor() as c:
+            c.execute(CREATE_SQL)
+            c.execute(f"TRUNCATE TABLE `{MYSQL_TABLE}`")
+            if rows:
+                collist = ", ".join(f"`{col}`" for col in COLS)
+                placeholders = ", ".join(f"%({col})s" for col in COLS)
+                sql = f"INSERT INTO `{MYSQL_TABLE}` ({collist}) VALUES ({placeholders})"
+                for i in range(0, len(rows), 500):
+                    c.executemany(sql, rows[i:i + 500])
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def main():
+    items = scan_external_articles()
+    rows = [to_row(it) for it in items]
+    logger.info(f"Scanned {len(items)} ExternalArticle items")
+    load(rows)
+    suppressed = sum(r["suppressed"] for r in rows)
+    logger.info(f"Loaded {len(rows)} rows into {MYSQL_TABLE} ({suppressed} suppressed)")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as e:
+        logger.exception(f"retrieveExternalArticles failed: {e}")
+        sys.exit(1)

--- a/update/run_all.py
+++ b/update/run_all.py
@@ -155,6 +155,22 @@ def run_pubmed_lane_if_due():
         logger.exception(f"PubMed lane failed (ignored — reporting unaffected): {e}")
 
 
+# ------------- External-source article projection (ReCiterDB #101) -------------
+def run_external_article_etl():
+    """Project the ExternalArticle DynamoDB table -> reciterdb.external_article.
+
+    Isolated (try/except + timeout) so a scan/load hiccup can never fail the nightly
+    reporting rebuild. Runs every night; robust to an empty/absent DynamoDB table.
+    NOTE: once reporting views/SPs consume external_article (ReCiterDB #101 reporting
+    inclusion), move this INTO the ordered `scripts` list BEFORE `nightlyIndexing` so
+    the stored procedures see freshly-loaded rows."""
+    try:
+        run_script("externalArticles", "python3 retrieveExternalArticles.py",
+                   timeout_seconds=int(os.getenv("EXTERNAL_ARTICLE_TIMEOUT_SECONDS", "600")))
+    except Exception as e:
+        logger.exception(f"External-article ETL failed (ignored — reporting unaffected): {e}")
+
+
 # ------------- Main Flow -------------
 def main():
     scripts = [
@@ -177,10 +193,12 @@ def main():
             logger.error("Stopping pipeline due to script failure.")
             break
 
-    # AAR lanes — run only if the reporting rebuild succeeded, weekly, each isolated.
+    # Post-reporting projections/lanes — run only if the reporting rebuild succeeded,
+    # each isolated so it can never fail the nightly.
     if overall_success:
-        run_scopus_lane_if_due()
-        run_pubmed_lane_if_due()
+        run_external_article_etl()            # nightly: ExternalArticle DynamoDB -> external_article
+        run_scopus_lane_if_due()              # weekly (Sun): AAR Scopus lane
+        run_pubmed_lane_if_due()              # weekly (Sun): AAR PubMed lane
 
     upload_log_to_s3()
 


### PR DESCRIPTION
Promotes the external-article reporting ETL from dev to master. Dedicated cherry-pick branch off `origin/master` (matches #106/#109/#113 convention), not a blanket dev→master.

Merged to dev in #110. Cherry-pick of `bd95ea4`.

## What it adds
- `setup/table_external_article.sql` — new `external_article` table
- `update/retrieveExternalArticles.py` — projects `ExternalArticle` (DynamoDB) → `external_article` (MySQL)
- `update/run_all.py` — wires the ETL into the nightly run
- `Dockerfile` — COPY the new script

Additive; Python compiles. Tested on dev per author.

Note: `AWS CodeBuild us-east-1 (ReCiterDB)` status = "Build not triggered: PR approval required" (webhook doesn't auto-build PRs) — same on #106/#109/#113, not a build failure.