### PR TITLE
Expose external article_id in analysis_summary_article (#101 downstream)

### DIFF
--- a/setup/alter_add_article_id_analysis_summary_article_v1.7.sql
+++ b/setup/alter_add_article_id_analysis_summary_article_v1.7.sql
@@ -1,0 +1,20 @@
+-- =============================================================================
+-- v1.7 — expose external article_id in analysis_summary_article (ReCiterDB #101 downstream)
+-- =============================================================================
+-- STEP 6b (populateAnalysisSummaryTables_v2) unions external_article rows into
+-- analysis_summary_article keyed on a SYNTHETIC NEGATIVE pmid that is recomputed
+-- every nightly run and shifts whenever the curated external set changes. That is
+-- fine as an internal join key, but SPS ingests these rows and needs a STABLE
+-- identity for external publications. `article_id` (the source-prefixed id, e.g.
+-- 'SCOPUS:105037533819' / 'OPENALEX:W2741809807') is stable, unique, and always
+-- present, so SPS keys external pubs on it instead of the synthetic pmid.
+--
+-- This migration adds the column so the SP's
+-- `CREATE TABLE analysis_summary_article_new LIKE analysis_summary_article`
+-- clones it into staging; STEP 6b then populates it (NULL for PubMed rows).
+--
+-- Apply BEFORE the next nightly run. Idempotent — safe to re-run.
+-- =============================================================================
+
+ALTER TABLE `analysis_summary_article`
+  ADD COLUMN IF NOT EXISTS `article_id` varchar(96) DEFAULT NULL;

--- a/setup/createDatabaseTableReciterDb.sql
+++ b/setup/createDatabaseTableReciterDb.sql
@@ -379,6 +379,7 @@ CREATE TABLE IF NOT EXISTS `analysis_summary_article` (
   `readersMendeley` int(11) DEFAULT NULL,
   `trendingPubsScore` float(7,2) DEFAULT NULL,
   `source_type` varchar(16) DEFAULT 'PUBMED',
+  `article_id` varchar(96) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `x` (`doi`) USING BTREE,
   KEY `z` (`pmid`) USING BTREE,

--- a/setup/populateAnalysisSummaryTables_v2.sql
+++ b/setup/populateAnalysisSummaryTables_v2.sql
@@ -1292,7 +1292,7 @@ proc_main: BEGIN
         INSERT INTO analysis_summary_article_new (
             pmid, articleTitle, journalTitleVerbose, doi, articleYear,
             publicationDateDisplay, publicationDateStandardized,
-            publicationTypeCanonical, source_type
+            publicationTypeCanonical, source_type, article_id
         )
         SELECT
             t.syn_pmid,
@@ -1303,7 +1303,11 @@ proc_main: BEGIN
             LEFT(MAX(e.pub_date), 200),
             LEFT(MAX(e.pub_date), 128),
             LEFT(MAX(e.publication_type), 128),
-            MAX(e.source_type)
+            MAX(e.source_type),
+            -- #101 downstream: expose the stable source-prefixed article_id so SPS can
+            -- key external pubs on it instead of the churning synthetic pmid. 1:1 with
+            -- syn_pmid (temp_external_pmid PK is article_id), so MAX() is exact.
+            MAX(t.article_id)
         FROM external_article e
         JOIN temp_external_pmid t ON t.article_id = e.article_id
         WHERE e.suppressed = 0


### PR DESCRIPTION
## What

Follow-up to the #101 union (PR #116). STEP 6b keys external `external_article` rows on a **synthetic negative pmid** that is recomputed every nightly run and shifts whenever the curated external set changes. Fine as an internal join key, but **SPS ingests these rows and needs a stable identity** for external publications.

This exposes the stable, source-prefixed `article_id` (e.g. `SCOPUS:105037533819`, `OPENALEX:W2741809807`) in `analysis_summary_article` so SPS keys external pubs on it instead of the churning synthetic pmid.

## Changes
- `createDatabaseTableReciterDb.sql` — add `article_id varchar(96)` to `analysis_summary_article` (cloned into `_new` via the SP's `LIKE`).
- `populateAnalysisSummaryTables_v2.sql` — STEP 6b article insert now populates `article_id` (`MAX(t.article_id)`, 1:1 with the synthetic pmid; NULL for PubMed rows).
- `alter_add_article_id_analysis_summary_article_v1.7.sql` — idempotent ALTER for live DBs; **apply before the next nightly**, mirroring the v1.6 source_type migration.

## Verified
Propagation exercised on MariaDB 11 (ephemeral): the edited 6b insert populates `article_id` for external rows under default sql_mode. Dormant — no rows until external pubs exist; PubMed rows unaffected (`article_id` NULL).

## Coordination
- **Downstream consumer: SPS PR wcmc-its/Scholars-Profile-System#1670** keys external `Publication` rows on this `article_id`. **Deploy this PR (and apply the v1.7 migration) before #1670 takes effect** — until `article_id` is populated, SPS falls back to the churning synthetic pmid.
- The #101 union landed on both `master` (#116) and `dev` (#117); this PR targets `master` — a `dev` cherry-pick may be wanted to keep them in sync per your workflow.
- Both sides are **dormant** until the upstream ReCiter #626 / PM #719 cutover (0 external rows until then), so this is safe to land ahead.
