### PR TITLE
Sync STEP 6b article_id into createEventsProceduresReciterDb (#101 follow-up to #118)

### DIFF
--- a/setup/createEventsProceduresReciterDb.sql
+++ b/setup/createEventsProceduresReciterDb.sql
@@ -4444,7 +4444,7 @@ proc_main: BEGIN
         INSERT INTO analysis_summary_article_new (
             pmid, articleTitle, journalTitleVerbose, doi, articleYear,
             publicationDateDisplay, publicationDateStandardized,
-            publicationTypeCanonical, source_type
+            publicationTypeCanonical, source_type, article_id
         )
         SELECT
             t.syn_pmid,
@@ -4455,7 +4455,11 @@ proc_main: BEGIN
             LEFT(MAX(e.pub_date), 200),
             LEFT(MAX(e.pub_date), 128),
             LEFT(MAX(e.publication_type), 128),
-            MAX(e.source_type)
+            MAX(e.source_type),
+            -- #101 downstream: expose the stable source-prefixed article_id so SPS can
+            -- key external pubs on it instead of the churning synthetic pmid. 1:1 with
+            -- syn_pmid (temp_external_pmid PK is article_id), so MAX() is exact.
+            MAX(t.article_id)
         FROM external_article e
         JOIN temp_external_pmid t ON t.article_id = e.article_id
         WHERE e.suppressed = 0


### PR DESCRIPTION
## Bug

`populateAnalysisSummaryTables_v2` is defined in **two** files — `setup/populateAnalysisSummaryTables_v2.sql` **and** `setup/createEventsProceduresReciterDb.sql`. The #101 union commit (`99a20d2`) correctly updated both. **#118 updated only the first**, so the two definitions drifted.

**Impact if not fixed:** deploying the procedure from `createEventsProceduresReciterDb.sql` would run STEP 6b but **never populate `article_id`** — no error, just a permanently NULL column. SPS would then silently fall back to the churning synthetic pmid, defeating the entire point of #118.

Caught while preparing to deploy the procedure (the live copy is still the 2026-05-06 version — see below).

## Fix
Mirror #118's change into `createEventsProceduresReciterDb.sql`'s STEP 6b article INSERT: add `article_id` to the column list and `MAX(t.article_id)` to the SELECT. Verified the two STEP 6b blocks are now **byte-identical** (`diff` clean; `article_id` ref counts 15 = 15).

## Context — the procedure is not deployed at all
Probing the live reciterdb: `populateAnalysisSummaryTables_v2` was **last altered 2026-05-06** (= commit `3ee47f7`) and has **no STEP 6b**. `run_nightly_indexing.sh` only `CALL`s the procedure — nothing deploys it — so the #101 union has never actually run. The v1.6 + v1.7 migrations have now been applied to the live DB, so the schema is ready; the procedure deploy is the remaining (activating) step.