### PR TITLE
fix(reporting): external_article collation silently blocks STEP 6b union (#101)

### DIFF
--- a/setup/alter_fix_external_article_collation_v1.8.sql
+++ b/setup/alter_fix_external_article_collation_v1.8.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- v1.8 — fix external_article collation so STEP 6b can actually join (ReCiterDB #101)
+-- =============================================================================
+-- `external_article` was created with `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4` and no
+-- COLLATE clause. Specifying the charset without a collation does NOT inherit the
+-- schema default — utf8mb4 resolves to utf8mb4_general_ci. That made external_article
+-- the only table in the reporting chain on general_ci; the reciterdb default and every
+-- table it joins against (analysis_summary_article, analysis_summary_author, person,
+-- person_article) are utf8mb4_unicode_ci.
+--
+-- STEP 6b (populateAnalysisSummaryTables_v2) does:
+--     JOIN temp_external_pmid t ON t.article_id = e.article_id
+-- temp_external_pmid is created inside the SP with no charset clause, so it takes the
+-- schema default (unicode_ci) while e.article_id is general_ci. The `=` then raises:
+--     Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT)
+--     and (utf8mb4_general_ci,IMPLICIT) for operation '='
+--
+-- This failed SILENTLY. STEP 6b is deliberately wrapped in a CONTINUE HANDLER so an
+-- injection error can never abort the reporting rebuild — so the nightly logged
+-- "External injection error (ignored)" and still finished SUCCESS, with ZERO external
+-- rows in analysis_summary_article. A green nightly was not evidence that 6b worked.
+--
+-- Fixing the table (rather than adding COLLATE clauses inside the SP) fixes every
+-- present and future join against external_article, not just the two in 6b.
+--
+-- external_article is a rebuildable projection of the ExternalArticle DynamoDB table
+-- (TRUNCATE + reload each nightly), so converting it cannot lose durable state. The
+-- nightly uses CREATE TABLE IF NOT EXISTS + TRUNCATE and never DROPs, so this
+-- conversion survives subsequent reloads.
+--
+-- Apply BEFORE the next nightly run. Idempotent — safe to re-run.
+-- =============================================================================
+
+ALTER TABLE `external_article`
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/setup/table_external_article.sql
+++ b/setup/table_external_article.sql
@@ -34,4 +34,8 @@ CREATE TABLE IF NOT EXISTS `external_article` (
   KEY `ix_source` (`source_type`),
   KEY `ix_doi` (`doi`),
   KEY `ix_suppressed` (`suppressed`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- COLLATE is load-bearing: `CHARSET=utf8mb4` alone means general_ci, but every join
+-- partner (analysis_summary_*, person) is unicode_ci. STEP 6b's join then raises
+-- "Illegal mix of collations" — which 6b swallows, so the nightly reports SUCCESS
+-- having injected zero external rows. See alter_fix_external_article_collation_v1.8.
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/update/retrieveExternalArticles.py
+++ b/update/retrieveExternalArticles.py
@@ -51,8 +51,11 @@ CREATE TABLE IF NOT EXISTS `external_article` (
   KEY `ix_source` (`source_type`),
   KEY `ix_doi` (`doi`),
   KEY `ix_suppressed` (`suppressed`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 """
+# Keep this DDL in sync with setup/table_external_article.sql. COLLATE is load-bearing:
+# without it utf8mb4 means general_ci, and STEP 6b's join against unicode_ci tables
+# fails silently (6b swallows the error; the nightly still reports SUCCESS).
 
 COLS = ["uid", "article_id", "source_type", "doi", "pmid", "title", "journal_or_venue",
         "authors", "pub_date", "publication_type", "added_by", "date_added", "method",


### PR DESCRIPTION
## Summary

STEP 6b (union external-source publications into `analysis_summary_article`) has never successfully injected a row. It fails on a collation mismatch, and because 6b is deliberately isolated in a `CONTINUE HANDLER`, the error is logged and swallowed — the nightly still reports `FINISHED / SUCCESS` while injecting **zero** external rows.

Found by running the #101 load-verify manually rather than waiting for the nightly. A green nightly would not have revealed it.

## Root cause

`external_article` is created with `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4` and **no `COLLATE`**. Specifying a charset without a collation does *not* inherit the schema default — utf8mb4 resolves to `utf8mb4_general_ci`. That made `external_article` the only table in the reporting chain on `general_ci`; the reciterdb default and every table it joins against (`analysis_summary_article`, `analysis_summary_author`, `person`, `person_article`) are `utf8mb4_unicode_ci`.

STEP 6b does:

```sql
JOIN temp_external_pmid t ON t.article_id = e.article_id
```

`temp_external_pmid` is created inside the SP with no charset clause, so it takes the schema default (`unicode_ci`) while `e.article_id` is `general_ci`. The `=` then raises:

```
Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT)
and (utf8mb4_general_ci,IMPLICIT) for operation '='
```

## Fix

Fix the **table**, not the procedure — that corrects every present and future join against `external_article`, not just the two inside 6b, and avoids re-deploying a 55KB procedure across its two source files.

- `setup/table_external_article.sql` — add `COLLATE=utf8mb4_unicode_ci`
- `update/retrieveExternalArticles.py` — same, in the `CREATE_SQL` that actually runs nightly
- `setup/alter_fix_external_article_collation_v1.8.sql` — migration for existing DBs (idempotent)

`external_article` is a rebuildable projection of the `ExternalArticle` DynamoDB table (`TRUNCATE` + reload nightly, never `DROP`), so the conversion loses no durable state and survives subsequent reloads.

## Verification (live reciterdb)

Applied the v1.8 ALTER, then re-ran `CALL populateAnalysisSummaryTables_v2()` end to end.

Before the fix — 6b errored, 0 rows:

```
24124 | External injection error (ignored - reporting unaffected) | ERROR
      | Illegal mix of collations ... for operation '='
```

After the fix — 6b completed, 2 + 2 rows:

```
24210 | Inserted external article rows      | INFO | rows=2
24211 | Inserted external author-link rows  | INFO | rows=2
24212 | Complete                            | DONE
```

Zero ERROR rows in the post-fix run (ids 24129–24216). All four success criteria pass:

| Check | Result |
|---|---|
| External rows landed w/ stable `article_id` | `SCOPUS:105037533819`, `SCOPUS:105039259995` (synthetic pmids -1/-2) |
| Linked to the right people | `sub9064`, `avl4004` |
| PubMed rows untouched | 309,725 `PUBMED` (unchanged) + 2 `SCOPUS` |
| Overall job | `FINISHED / SUCCESS` |

## Note

The live table has **already been converted** (the ALTER above), so the next nightly will inject correctly with or without this merge. This PR makes a fresh DB build correct and records the migration.

Refs #101.