### PR TITLE
fix(reporting): external_article collation silently blocks STEP 6b union (#101) [dev]

### DIFF
--- a/setup/alter_fix_external_article_collation_v1.8.sql
+++ b/setup/alter_fix_external_article_collation_v1.8.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- v1.8 — fix external_article collation so STEP 6b can actually join (ReCiterDB #101)
+-- =============================================================================
+-- `external_article` was created with `ENGINE=InnoDB DEFAULT CHARSET=utf8mb4` and no
+-- COLLATE clause. Specifying the charset without a collation does NOT inherit the
+-- schema default — utf8mb4 resolves to utf8mb4_general_ci. That made external_article
+-- the only table in the reporting chain on general_ci; the reciterdb default and every
+-- table it joins against (analysis_summary_article, analysis_summary_author, person,
+-- person_article) are utf8mb4_unicode_ci.
+--
+-- STEP 6b (populateAnalysisSummaryTables_v2) does:
+--     JOIN temp_external_pmid t ON t.article_id = e.article_id
+-- temp_external_pmid is created inside the SP with no charset clause, so it takes the
+-- schema default (unicode_ci) while e.article_id is general_ci. The `=` then raises:
+--     Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT)
+--     and (utf8mb4_general_ci,IMPLICIT) for operation '='
+--
+-- This failed SILENTLY. STEP 6b is deliberately wrapped in a CONTINUE HANDLER so an
+-- injection error can never abort the reporting rebuild — so the nightly logged
+-- "External injection error (ignored)" and still finished SUCCESS, with ZERO external
+-- rows in analysis_summary_article. A green nightly was not evidence that 6b worked.
+--
+-- Fixing the table (rather than adding COLLATE clauses inside the SP) fixes every
+-- present and future join against external_article, not just the two in 6b.
+--
+-- external_article is a rebuildable projection of the ExternalArticle DynamoDB table
+-- (TRUNCATE + reload each nightly), so converting it cannot lose durable state. The
+-- nightly uses CREATE TABLE IF NOT EXISTS + TRUNCATE and never DROPs, so this
+-- conversion survives subsequent reloads.
+--
+-- Apply BEFORE the next nightly run. Idempotent — safe to re-run.
+-- =============================================================================
+
+ALTER TABLE `external_article`
+  CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/setup/table_external_article.sql
+++ b/setup/table_external_article.sql
@@ -34,4 +34,8 @@ CREATE TABLE IF NOT EXISTS `external_article` (
   KEY `ix_source` (`source_type`),
   KEY `ix_doi` (`doi`),
   KEY `ix_suppressed` (`suppressed`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+-- COLLATE is load-bearing: `CHARSET=utf8mb4` alone means general_ci, but every join
+-- partner (analysis_summary_*, person) is unicode_ci. STEP 6b's join then raises
+-- "Illegal mix of collations" — which 6b swallows, so the nightly reports SUCCESS
+-- having injected zero external rows. See alter_fix_external_article_collation_v1.8.
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/update/retrieveExternalArticles.py
+++ b/update/retrieveExternalArticles.py
@@ -51,8 +51,11 @@ CREATE TABLE IF NOT EXISTS `external_article` (
   KEY `ix_source` (`source_type`),
   KEY `ix_doi` (`doi`),
   KEY `ix_suppressed` (`suppressed`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 """
+# Keep this DDL in sync with setup/table_external_article.sql. COLLATE is load-bearing:
+# without it utf8mb4 means general_ci, and STEP 6b's join against unicode_ci tables
+# fails silently (6b swallows the error; the nightly still reports SUCCESS).
 
 COLS = ["uid", "article_id", "source_type", "doi", "pmid", "title", "journal_or_venue",
         "authors", "pub_date", "publication_type", "added_by", "date_added", "method",


### PR DESCRIPTION
Dev counterpart of **#120** (merged to `master` as `1465728c`). Cherry-pick, no changes.

## Why

`external_article` is created with `DEFAULT CHARSET=utf8mb4` and **no `COLLATE`**. A charset without a collation does not inherit the schema default — utf8mb4 resolves to `utf8mb4_general_ci`, leaving `external_article` as the only table in the reporting chain on `general_ci` while every table it joins (`analysis_summary_article`, `analysis_summary_author`, `person`, `person_article`) is `utf8mb4_unicode_ci`.

STEP 6b's `JOIN temp_external_pmid t ON t.article_id = e.article_id` therefore raises:

```
Illegal mix of collations (utf8mb4_unicode_ci,IMPLICIT)
and (utf8mb4_general_ci,IMPLICIT) for operation '='
```

**It fails silently.** 6b is isolated in a `CONTINUE HANDLER`, so the error is logged and swallowed and the reporting rebuild still reports `FINISHED / SUCCESS` — with zero external rows injected. A green nightly was never evidence that 6b worked.

## Changes

- `setup/table_external_article.sql` — add `COLLATE=utf8mb4_unicode_ci`
- `update/retrieveExternalArticles.py` — same, in the `CREATE_SQL` that actually runs nightly
- `setup/alter_fix_external_article_collation_v1.8.sql` — idempotent migration for existing DBs

Fixes the **table**, not the procedure, so every present and future join against `external_article` is correct — not just the two inside 6b.

The v1.8 filename is kept identical to master's on purpose, so the branches don't later produce duplicate migration files. (dev has no v1.7; that one was master-only.)

## Verified on the live reciterdb (via #120)

Applied the ALTER, then ran the real projection ETL and the full rebuild end to end. Before: 6b `ERROR`, 0 rows. After: 6b `Complete / DONE`, external rows injected, 0 errors, `FINISHED / SUCCESS`, PubMed untouched at 309,725. Both `SCOPUS` and `OPENALEX` source types confirmed to flow (`OPENALEX` inserts into the ENUM with no coercion).

Also confirmed the live ALTER survives the nightly: the projection ETL uses `CREATE TABLE IF NOT EXISTS` + `TRUNCATE` and never `DROP`, so the collation persists across reloads.

Refs #101.