### PR TITLE
fix(import): accept s3StorageFlag as the offload flag alongside usingS3

### DIFF
--- a/update/retrieveArticles.py
+++ b/update/retrieveArticles.py
@@ -431,8 +431,12 @@ def main():
     for chunk in yield_analysis_items_in_chunks(table_name="Analysis", page_size=CHUNK_SIZE):
         logger.info(f"Processing chunk of {len(chunk)} items from Analysis.")
         for item in chunk:
+            # ReCiter writes the offload flag as s3StorageFlag (BOOL); older rows use
+            # usingS3 (N). Both forms are live in the table, so accept either. Reading
+            # only usingS3 silently routes an offloaded row to direct_buffer, where its
+            # 200-byte pointer yields no articles and the person imports zero rows.
             using_s3_val = item.get("usingS3", 0)
-            if using_s3_val == 1:
+            if using_s3_val == 1 or item.get("s3StorageFlag") is True:
                 s3_buffer.append(item)
             else:
                 direct_buffer.append(item)

--- a/update/retrieveArticles.py
+++ b/update/retrieveArticles.py
@@ -431,12 +431,21 @@ def main():
     for chunk in yield_analysis_items_in_chunks(table_name="Analysis", page_size=CHUNK_SIZE):
         logger.info(f"Processing chunk of {len(chunk)} items from Analysis.")
         for item in chunk:
-            # ReCiter writes the offload flag as s3StorageFlag (BOOL); older rows use
-            # usingS3 (N). Both forms are live in the table, so accept either. Reading
-            # only usingS3 silently routes an offloaded row to direct_buffer, where its
-            # 200-byte pointer yields no articles and the person imports zero rows.
-            using_s3_val = item.get("usingS3", 0)
-            if using_s3_val == 1 or item.get("s3StorageFlag") is True:
+            # The offload flag lives under two names and inconsistent types:
+            #   s3StorageFlag - BOOL, written by current ReCiter
+            #   usingS3       - legacy; N 0/1 on most rows but BOOL on ~1,660
+            # Reading only usingS3 sends an s3StorageFlag row to direct_buffer, where
+            # its 200-byte pointer yields no articles and the person imports zero rows.
+            # s3StorageFlag wins where both exist: it is the newer writer's signal, and
+            # a row that shrank back under the offload threshold keeps a stale usingS3=1
+            # alongside s3StorageFlag=false + inline data, so trusting usingS3 there
+            # would import a long-dead S3 payload instead of the current inline one.
+            # bool() rather than `is True` so an N-typed flag still reads correctly.
+            if "s3StorageFlag" in item:
+                use_s3 = bool(item["s3StorageFlag"])
+            else:
+                use_s3 = item.get("usingS3", 0) == 1
+            if use_s3:
                 s3_buffer.append(item)
             else:
                 direct_buffer.append(item)


### PR DESCRIPTION
## Summary

Large (S3-offloaded) people import **zero rows** into `person_article`, collapsing `analysis_summary_*` and freezing SPS publication data since 07-10. Root cause is a **flag name mismatch in the importer**, not damaged data.

`update/retrieveArticles.py` classified Analysis rows by `usingS3` only:

```python
using_s3_val = item.get("usingS3", 0)
if using_s3_val == 1:
    s3_buffer.append(item)      # download payload from S3
else:
    direct_buffer.append(item)  # read articles inline
```

ReCiter writes the offload flag as **`s3StorageFlag` (BOOL)**. For those rows `.get("usingS3", 0)` returns the default `0`, so an offloaded row is routed to `direct_buffer` — where its 200-byte pointer contains no articles and the person imports **zero rows**.

This fully explains the observed signature:
- **All-or-nothing loss** — 879 of 896 affected people went to exactly zero, nobody lost "some".
- **Monotonic size gradient** — 46.4% of the largest quartile zeroed vs 1.0% of the smallest; only payloads >400KB are offloaded, so only they carry the flag.
- **S3 payloads are intact.** Sampled 14 affected uids across all cohorts: every object is well-formed with full article counts and **zero** null-evidence blocks (`sfs2002` = 2,072 articles / 15.6MB, matching its reported loss exactly).

## Why re-scoring does not fix it

A forced `feature-generator` re-score against the fixed ReCiter image (628) rewrites the S3 object but writes back the **same `s3StorageFlag` attribute**, so the importer still misses the row. Confirmed empirically: re-scoring `joj9026` produced an object byte-identical to its predecessor except for `dateAdded`/`dateUpdated`, and its Analysis row still reads `s3StorageFlag`. A mass re-score is a no-op for this bug.

The set is also still **growing**: of the S3 objects written since image 628 deployed at 11:30 UTC, 400/400 sampled rows carry `s3StorageFlag` and 0 carry `usingS3`. Every inst-client run adds more zero-row people until the importer tolerates both names.

## Scope: 1,923 rows, not 1,230

The affected set was previously estimated by filtering S3 objects on `LastModified`, which both over- and under-counts. Census of the live Analysis table by attribute:

| rows | attribute | importer sees | status |
|---:|---|---|---|
| **1,923** | `s3StorageFlag: true` | `usingS3` absent → `0` | ❌ imports zero |
| 8,037 | `s3StorageFlag: false` | → `0` | ✅ inline, correct |
| 637 | `usingS3` truthy | → `1` | ✅ S3 path |
| 30,357 | `usingS3` falsy / inline | → `0` | ✅ direct |

The mtime-derived set of 1,230 contains 42 rows that are not broken and **misses 735 that are** (e.g. `ajg9004`, last written 07-06, outside the window but carrying `s3StorageFlag`).

## The fix

Both attribute names are live in the table (1,923 new + 637 old), so tolerating both is required regardless of any future writer reconciliation — and it needs no data migration and no re-scoring.

Two details beyond the name:

**Type tolerance.** `usingS3` is stored with inconsistent types — `N 0`×20,696, `N 1`×598, `BOOL false`×1,623, `BOOL true`×39. The existing `== 1` test only survives the 39 BOOL-true rows via Python's `True == 1` quirk. `s3StorageFlag` is uniformly BOOL today, but given the demonstrated drift this uses `bool()` rather than `is True` so an N-typed flag would still read correctly.

**Precedence.** Where both attributes exist, `s3StorageFlag` wins — it is the current writer's signal. A row that shrank back under the 400KB threshold keeps a stale `usingS3=1` beside `s3StorageFlag=false` and inline features. **`adg9009` is exactly this case**: `usingS3=1`, `s3StorageFlag=false`, inline `reCiterFeature` present, S3 object last written **2025-08-27**. Today's logic imports that year-old payload for them; preferring `s3StorageFlag` reads their current inline features instead.

## Verification

Replayed old vs new classification over the **live** Analysis table through the resource API (the same access path the importer uses, so `s3StorageFlag` deserializes to a real `bool` and `usingS3` to `Decimal`):

```
old=direct new=direct       30357
old=direct new=s3            1923   <- the broken set, now fixed
old=s3     new=direct           1   <- adg9009 only; intended (see Precedence)
old=s3     new=s3             636
```

`python3 -m py_compile update/retrieveArticles.py` passes.

Not yet verified, since both need a cron run: that the import actually produces rows, and that SPS's guard clears.

## Rollout

`update/run_all.py` runs `retrieveArticles.py` in the nightly `reciterdb` CronJob (04:15 UTC). Once this is on the deployed master image, the next run imports all 1,923 people and `analysis_summary_*` should recover; SPS's volume guard is then expected to clear on its own at 07:00 UTC.

Expect a **longer run than the usual ~95 min** — roughly 2,500 S3 objects now download that were previously skipped, some up to 15MB.

Do **not** set `ETL_GUARD_BYPASS` — the guard is what is keeping the loss out of SPS prod.

Note: the ReCiterDB build auto-deploys the **image only**; do not `kubectl apply` the repo's `k8-cronjob.yaml` (its `30 17` schedule would clobber the live `15 4`).

## Follow-ups (not in this PR)

- Mirror to `dev` to keep the branches in sync.
- `update/retrieveDynamoDb.py` uses `filter_expr = "usingS3 = :val"`, which cannot match `s3StorageFlag` rows either. It is not in the `run_all.py` nightly path, so it is left alone here.
- Reconcile the ReCiter writer on one attribute name, then migrate rows and simplify this condition. Note image 628 currently writes `s3StorageFlag`, reverting the direction dynamodb-model v3.0.4 set on 07-14.
- `drw2004` / `sha2054` are zeroed with no S3 object at all — a separate cause, unaffected by this fix.