### PR TITLE
fix(import): accept s3StorageFlag as the offload flag alongside usingS3 (port of #123 to dev)

### DIFF
--- a/update/retrieveArticles.py
+++ b/update/retrieveArticles.py
@@ -431,8 +431,21 @@ def main():
     for chunk in yield_analysis_items_in_chunks(table_name="Analysis", page_size=CHUNK_SIZE):
         logger.info(f"Processing chunk of {len(chunk)} items from Analysis.")
         for item in chunk:
-            using_s3_val = item.get("usingS3", 0)
-            if using_s3_val == 1:
+            # The offload flag lives under two names and inconsistent types:
+            #   s3StorageFlag - BOOL, written by current ReCiter
+            #   usingS3       - legacy; N 0/1 on most rows but BOOL on ~1,660
+            # Reading only usingS3 sends an s3StorageFlag row to direct_buffer, where
+            # its 200-byte pointer yields no articles and the person imports zero rows.
+            # s3StorageFlag wins where both exist: it is the newer writer's signal, and
+            # a row that shrank back under the offload threshold keeps a stale usingS3=1
+            # alongside s3StorageFlag=false + inline data, so trusting usingS3 there
+            # would import a long-dead S3 payload instead of the current inline one.
+            # bool() rather than `is True` so an N-typed flag still reads correctly.
+            if "s3StorageFlag" in item:
+                use_s3 = bool(item["s3StorageFlag"])
+            else:
+                use_s3 = item.get("usingS3", 0) == 1
+            if use_s3:
                 s3_buffer.append(item)
             else:
                 direct_buffer.append(item)


### PR DESCRIPTION
Port of #123 to `dev`, to keep the branches in sync. `dev` carried the identical `usingS3`-only classification, so the same 1,923 Analysis rows would import zero articles from here.

## What was wrong

`update/retrieveArticles.py` classified Analysis rows by `usingS3` only. ReCiter writes the offload flag as **`s3StorageFlag` (BOOL)**, so `.get("usingS3", 0)` returned the default `0` and routed an offloaded row to `direct_buffer` — where its 200-byte S3 pointer contains no articles and the person imports **zero rows**. On master this was the root cause of the 07-10 → 07-16 SPS publication freeze (879 people zeroed, all-or-nothing, size-graded). The S3 payloads themselves were never damaged.

## The fix

Accept either attribute name, with two refinements carried over from #123:

- **Precedence** — `s3StorageFlag` wins where both exist. A row that shrank back under the 400KB offload threshold keeps a stale `usingS3=1` beside `s3StorageFlag=false` and inline features (`adg9009`: S3 object last written 2025-08-27), so trusting `usingS3` there imports a year-old payload.
- **Type tolerance** — `bool()` rather than `is True`, since `usingS3` is stored with mixed types across the table (`N 0`×20,696, `N 1`×598, `BOOL false`×1,623, `BOOL true`×39) and the same drift is possible for `s3StorageFlag`.

## Verification

Identical to #123, which merged to master as `8aa9fc9d`. This branch's `update/retrieveArticles.py` is byte-identical to master's. Replayed over the live Analysis table via the resource API: 1,923 rows move direct→S3, and the only S3→direct move is `adg9009` (intended). `python3 -m py_compile` passes.

Note `update/retrieveDynamoDb.py` uses `filter_expr = "usingS3 = :val"` and cannot match `s3StorageFlag` rows either; it is not in the `run_all.py` nightly path, so it is left alone here as on master.