### PR TITLE
fix(conflictsImport): replace CSV bulk load with parameterized executemany [dev]

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ All defined in `setup/createEventsProceduresReciterDb.sql`.
 | `dataTransformer.py` | Transforms ReCiter JSON output to CSV format for all `person_*` tables |
 | `run_nightly_indexing.sh` | Calls `populateAnalysisSummaryTables_v2()` with progress monitoring, auto-retry, and auto-restore |
 | `abstractImport.py` | Imports PubMed abstracts from DynamoDB (parallel batch fetches) |
-| `conflictsImport.py` | Imports conflict-of-interest statements from DynamoDB |
+| `conflictsImport.py` | Imports conflict-of-interest statements from DynamoDB (parallel batch fetches) |
 | `executeFeatureGenerator.py` | Triggers ReCiter feature generator API with rate limiting and metrics |
 
 

--- a/update/auditConflictsVsDynamo.py
+++ b/update/auditConflictsVsDynamo.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Compare stored reporting_conflicts text against DynamoDB truth (#127). READ-ONLY.
+
+audit_conflicts.sql can only ask "does this table look internally odd?". It cannot
+tell whether a stored statement matches its source, and it cannot tell an escaping
+bug apart from ordinary staleness. This can: it samples rows, refetches each pmid
+from DynamoDB, and classifies stored-vs-source.
+
+Reads a stratified sample rather than the whole table -- the high-risk classes are
+taken exhaustively, plus a random baseline for an unbiased rate.
+
+The discriminator that matters: if statements are missing because the old
+CSV/LOAD DATA path mis-escaped them, essentially ALL of the missing ones must
+contain a quote, tab, newline or backslash, because that is the only mechanism by
+which that bug drops content. If the poison rate among the missing matches the
+population base rate instead, the cause is staleness, not corruption -- rows are
+written once and `LEFT JOIN ... WHERE a.pmid IS NULL` never revisits them, so a
+statement PubMed adds after first import stays invisible forever.
+
+Measured 2026-07-28 against reciterdb: 96.9% MATCH over 1,660 sampled rows, zero
+escaping damage, and 5.9% of empty rows (~5,100 table-wide) carrying a statement in
+DynamoDB of which only 4% held poison characters -- i.e. staleness, not #127.
+
+Run: python3 auditConflictsVsDynamo.py [--sample-empty N]
+"""
+import argparse, collections, concurrent.futures, math, os, sys
+import boto3
+import pymysql.cursors
+
+CHUNK_SIZE = 100
+MAX_WORKERS = 5
+MAX_UNPROCESSED_RETRIES = 8
+POISON = ('"', '\t', '\n', '\r', '\\')
+
+
+def connect():
+    return pymysql.connect(
+        user=os.environ["DB_USERNAME"], password=os.environ["DB_PASSWORD"],
+        host=os.environ["DB_HOST"], database=os.environ["DB_NAME"],
+        charset="utf8mb4", cursorclass=pymysql.cursors.DictCursor)
+
+
+def strata(n_empty):
+    # RAND(<seed>) so a re-run after a fix samples the same rows and the before/after
+    # numbers are comparable rather than two different random draws.
+    return {
+        "has_quote":    ("SELECT pmid, conflictStatement b FROM reporting_conflicts "
+                         "WHERE LENGTH(conflictStatement)>0 AND CONVERT(conflictStatement USING utf8mb4) LIKE '%\"%'"),
+        "longest":      ("SELECT pmid, conflictStatement b FROM reporting_conflicts "
+                         "WHERE LENGTH(conflictStatement)>5000 ORDER BY LENGTH(conflictStatement) DESC LIMIT 300"),
+        "random_filled":("SELECT pmid, conflictStatement b FROM reporting_conflicts "
+                         "WHERE LENGTH(conflictStatement)>0 ORDER BY RAND(11) LIMIT 600"),
+        "random_empty": ("SELECT pmid, conflictStatement b FROM reporting_conflicts "
+                         f"WHERE LENGTH(conflictStatement)=0 ORDER BY RAND(42) LIMIT {int(n_empty)}"),
+    }
+
+
+def get_coi(item):
+    mc = item.get("pubmedarticle", {}).get("medlinecitation")
+    return (mc.get("coiStatement") or "") if mc else ""
+
+
+def fetch_chunk(chunk):
+    client = boto3.resource("dynamodb").meta.client
+    keys, out, attempt = [{"pmid": p} for p in chunk], {}, 0
+    while keys:
+        r = client.batch_get_item(RequestItems={"PubMedArticle": {"Keys": keys}})
+        for it in r["Responses"].get("PubMedArticle", []):
+            out[int(it["pmid"])] = get_coi(it)
+        keys = r.get("UnprocessedKeys", {}).get("PubMedArticle", {}).get("Keys", [])
+        attempt += 1
+        if attempt > MAX_UNPROCESSED_RETRIES:
+            print(f"  warning: {len(keys)} key(s) unprocessed after retries", file=sys.stderr)
+            break
+    return out
+
+
+def classify(db, dyn, present):
+    if not present:                 return "NOT_IN_DYNAMO"
+    if db == dyn:                   return "MATCH"
+    if db.strip() == dyn.strip():   return "MATCH_WHITESPACE"
+    if not db and dyn:              return "MISSING_FROM_DB"
+    if db and not dyn:              return "EXTRA_IN_DB"
+    if dyn.startswith(db):          return "TRUNCATED"
+    if db.startswith(dyn):          return "APPENDED"
+    return "MISMATCH_OTHER"
+
+
+def wilson(k, n):
+    if not n:
+        return 0.0, 0.0
+    p, z = k / n, 1.96
+    den = 1 + z * z / n
+    ctr = (p + z * z / (2 * n)) / den
+    mrg = z / den * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    return max(0.0, ctr - mrg), min(1.0, ctr + mrg)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sample-empty", type=int, default=3000,
+                    help="how many empty rows to sample (drives the staleness estimate)")
+    args = ap.parse_args()
+
+    conn = connect()
+    stored, member_of = {}, collections.defaultdict(set)
+    for name, sql in strata(args.sample_empty).items():
+        with conn.cursor() as c:
+            c.execute(sql)
+            rows = c.fetchall()
+        for r in rows:
+            b = r["b"]
+            stored[r["pmid"]] = b.decode("utf-8", "replace") if isinstance(b, bytes) else (b or "")
+            member_of[name].add(r["pmid"])
+        print(f"  stratum {name}: {len(rows)} rows", file=sys.stderr)
+    with conn.cursor() as c:
+        c.execute("SELECT COUNT(*) n FROM reporting_conflicts WHERE LENGTH(conflictStatement)=0")
+        total_empty = c.fetchone()["n"]
+    conn.close()
+
+    pmids = list(stored)
+    truth = {}
+    chunks = [pmids[i:i + CHUNK_SIZE] for i in range(0, len(pmids), CHUNK_SIZE)]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as ex:
+        for f in concurrent.futures.as_completed([ex.submit(fetch_chunk, c) for c in chunks]):
+            truth.update(f.result())
+    print(f"sampled {len(pmids)} pmids; DynamoDB answered {len(truth)}\n", file=sys.stderr)
+
+    tally = collections.Counter()
+    for p in pmids:
+        tally[classify(stored[p], truth.get(p, ""), p in truth)] += 1
+    print("=== stored vs DynamoDB ===")
+    for k, v in tally.most_common():
+        print(f"  {k:20s} {v:6d}  ({100*v/len(pmids):5.2f}%)")
+
+    # The staleness estimate and the blame probe.
+    empties = member_of["random_empty"]
+    missing = [p for p in empties if truth.get(p, "")]
+    lo, hi = wilson(len(missing), len(empties))
+    print(f"\n=== empty rows that DO have a statement upstream ===")
+    print(f"  {len(missing)} of {len(empties)} sampled = {100*len(missing)/max(1,len(empties)):.2f}% "
+          f"(95% CI {100*lo:.2f}%..{100*hi:.2f}%)")
+    print(f"  {total_empty} empty rows in table => approx {int(len(missing)/max(1,len(empties))*total_empty)} "
+          f"affected (range {int(lo*total_empty)}..{int(hi*total_empty)})")
+
+    poisoned = [p for p in missing if any(c in truth[p] for c in POISON)]
+    base = [p for p in pmids if truth.get(p, "") and any(c in truth[p] for c in POISON)]
+    have = [p for p in pmids if truth.get(p, "")]
+    print(f"\n=== blame probe ===")
+    print(f"  poison chars among the MISSING   : {len(poisoned)}/{len(missing)} "
+          f"({100*len(poisoned)/max(1,len(missing)):.1f}%)")
+    print(f"  poison chars in the POPULATION   : {len(base)}/{len(have)} "
+          f"({100*len(base)/max(1,len(have)):.1f}%)")
+    print("  near 100% among the missing => CSV/LOAD DATA escaping damage.")
+    print("  comparable to the population => staleness: the backfill never revisits an existing row.")
+
+
+if __name__ == "__main__":
+    main()

--- a/update/audit_conflicts.sql
+++ b/update/audit_conflicts.sql
@@ -47,10 +47,17 @@ WHERE p.articleYear >= 2017
 -- Q2. The escaping skew -- the tell the issue calls out.
 --
 -- LOAD DATA defaulted to ESCAPED BY '\\', so a backslash in the source text was
--- consumed as an escape character rather than stored as data. If essentially no
--- stored statement contains a backslash while a meaningful share contain other
--- punctuation, the backslashes were eaten. A doubled quote ("") is csv.writer's
--- escaping leaking through as literal data.
+-- consumed as an escape character rather than stored as data. A doubled quote ("")
+-- is csv.writer's escaping leaking through as literal data.
+--
+-- CALIBRATION, measured on the live table 2026-07-28: 1 backslash and 65 quotes in
+-- 74,170 non-empty statements. That looks alarming and is NOT -- COI statements are
+-- short stereotyped prose (64% under 200 bytes) whose natural backslash rate really
+-- is near zero, and the one hit is a genuine 'http:\<...>' stored intact. A verbatim
+-- DynamoDB comparison over 1,660 sampled rows found ZERO escaping damage.
+-- contains_comma_control is the control: it must be large (it was 27,251), proving
+-- the LIKE machinery works and a low backslash count is a real base rate, not a
+-- broken query. Do not read a low backslash count here as corruption on its own.
 -- ---------------------------------------------------------------------------
 SELECT 'Q2 escaping skew' AS check_name,
        COUNT(*)                                                                  AS nonempty_rows,
@@ -63,33 +70,40 @@ FROM reporting_conflicts
 WHERE LENGTH(conflictStatement) > 0;
 
 -- ---------------------------------------------------------------------------
--- Q3. Cross-paper concatenation -- the #87/#89/#88 shape.
+-- Q3. Cross-paper contamination -- the #87/#89/#88 shape.
 --
--- COI statements are highly stereotyped. A row where the boilerplate opening
--- appears two or more times is two papers' text welded together by a desynced
--- LOAD DATA parse. Occurrence count via the standard length-of-REPLACE idiom.
+-- Detect it as one long statement appearing under MORE THAN ONE pmid. A desynced
+-- reader assigns the same text to several rows, so a shared fingerprint is the
+-- signature; a length threshold keeps short shared boilerplate ("None declared.")
+-- out, since that repeats legitimately across thousands of papers.
+--
+-- DO NOT go back to counting repeated boilerplate ("competing interest" appearing
+-- twice in one row). That was tried and measured against the live table: it
+-- flagged 5,272 rows, essentially all false positives, because the standard
+-- Elsevier header "Declaration of Competing Interest ... may be considered as
+-- potential competing interests" legitimately contains the phrase twice. A
+-- detector that fires on 7% of a healthy table is worse than no detector.
 -- ---------------------------------------------------------------------------
-SELECT 'Q3 concatenation' AS check_name,
-       COUNT(*) AS suspect_rows
-FROM reporting_conflicts
-WHERE LENGTH(conflictStatement) > 0
-  AND ( CHAR_LENGTH(LOWER(CONVERT(conflictStatement USING utf8mb4)))
-        - CHAR_LENGTH(REPLACE(LOWER(CONVERT(conflictStatement USING utf8mb4)),
-                              'competing interest', ''))
-      ) / CHAR_LENGTH('competing interest') >= 2;
+SELECT 'Q3 contamination' AS check_name,
+       COUNT(*)         AS shared_texts,
+       COALESCE(SUM(n_pmids), 0) AS rows_involved
+FROM (SELECT MD5(conflictStatement) AS h, COUNT(DISTINCT pmid) AS n_pmids
+      FROM reporting_conflicts
+      WHERE LENGTH(conflictStatement) > 1000
+      GROUP BY h
+      HAVING COUNT(DISTINCT pmid) > 1) x;
 
--- The worst offenders, to eyeball. If these read as one coherent statement the
--- detector is just seeing a wordy disclosure; if they read as two papers, it is real.
-SELECT pmid,
-       LENGTH(conflictStatement) AS blob_bytes,
-       LEFT(CONVERT(conflictStatement USING utf8mb4), 300) AS head_300
+-- Eyeball these. Co-authors on a consortium paper and same-group submissions do
+-- legitimately share a long disclosure, so a handful here is normal; what is not
+-- normal is one text spread across many unrelated pmids.
+SELECT COUNT(DISTINCT pmid) AS n_pmids,
+       MIN(LENGTH(conflictStatement)) AS blob_bytes,
+       LEFT(CONVERT(MIN(conflictStatement) USING utf8mb4), 200) AS head_200
 FROM reporting_conflicts
-WHERE LENGTH(conflictStatement) > 0
-  AND ( CHAR_LENGTH(LOWER(CONVERT(conflictStatement USING utf8mb4)))
-        - CHAR_LENGTH(REPLACE(LOWER(CONVERT(conflictStatement USING utf8mb4)),
-                              'competing interest', ''))
-      ) / CHAR_LENGTH('competing interest') >= 2
-ORDER BY LENGTH(conflictStatement) DESC
+WHERE LENGTH(conflictStatement) > 1000
+GROUP BY MD5(conflictStatement)
+HAVING COUNT(DISTINCT pmid) > 1
+ORDER BY n_pmids DESC, blob_bytes DESC
 LIMIT 10;
 
 -- ---------------------------------------------------------------------------
@@ -103,9 +117,14 @@ LIMIT 10;
 -- utf8mb4_unicode_ci, under which REGEXP '^[a-z]' matches uppercase too and every
 -- healthy row is reported as a desync. Verified against a seeded fixture -- without
 -- the binary collation this counted 7 of 9 rows instead of the 1 that is real.
+--
+-- starts_punctuation excludes a leading '<': PubMed ships COI statements containing
+-- its own HTML markup, and on the live table 8,646 of 8,646 punctuation-starts were
+-- just '<b>Conflict of Interest...'. Without the exclusion this reads as 12% corruption.
 SELECT 'Q4 desync tells' AS check_name,
        SUM(CONVERT(conflictStatement USING utf8mb4) COLLATE utf8mb4_bin REGEXP '^[a-z]') AS starts_lowercase,
-       SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]') AS starts_punctuation,
+       SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]'
+           AND CONVERT(conflictStatement USING utf8mb4) NOT LIKE '<%') AS starts_punctuation,
        SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[0-9]+$')     AS is_bare_number,
        MAX(LENGTH(conflictStatement))                                      AS max_blob_bytes,
        SUM(LENGTH(conflictStatement) >= 65535)                             AS at_blob_ceiling

--- a/update/audit_conflicts.sql
+++ b/update/audit_conflicts.sql
@@ -1,0 +1,125 @@
+-- audit_conflicts.sql -- read-only damage assessment for reporting_conflicts (#127)
+--
+-- PR #128/#129 stops conflictsImport.py from CORRUPTING new rows. It repairs
+-- nothing: the backfill is `LEFT JOIN ... WHERE a.pmid IS NULL`, so a row that
+-- already holds truncated or concatenated text is never revisited.
+--
+-- This answers "is there anything to repair?" without touching DynamoDB. Run it
+-- first. Only if it shows damage is it worth porting auditAbstracts.py (which
+-- compares every row against DynamoDB truth) to conflicts.
+--
+-- Every query reads the BLOB `conflictStatement`, never `conflictsVarchar` --
+-- the varchar truncates at 15000 and will understate the damage. CONVERT(...)
+-- is required because string functions treat a blob as case-sensitive bytes.
+--
+-- Read-only: no INSERT/UPDATE/DELETE/DDL anywhere in this file.
+--
+-- Run: mysql -h "$DB_HOST" -u "$DB_USERNAME" -p "$DB_NAME" < audit_conflicts.sql
+
+-- ---------------------------------------------------------------------------
+-- Q1. Coverage and duplicates.
+--
+-- Note reporting_conflicts has only KEY idx_pmid, NOT the UNIQUE key that
+-- alter_add_uq_pmid_reporting_abstracts_v1.4.sql added to reporting_abstracts
+-- after the #87 incident. Duplicate pmids are therefore possible here and are
+-- worth knowing about before any repair.
+-- ---------------------------------------------------------------------------
+SELECT 'Q1 coverage' AS check_name,
+       COUNT(*)                                             AS rows_total,
+       COUNT(DISTINCT pmid)                                 AS pmids_distinct,
+       COUNT(*) - COUNT(DISTINCT pmid)                      AS duplicate_rows,
+       SUM(conflictStatement IS NULL OR LENGTH(conflictStatement) = 0) AS empty_statements,
+       SUM(LENGTH(conflictStatement) > 0)                   AS nonempty_statements
+FROM reporting_conflicts;
+
+-- Eligible population the importer targets, for comparison against rows_total.
+-- COUNT(DISTINCT ...) rather than SUM(): a duplicated pmid in reporting_conflicts
+-- fans the join out, so a plain row count would misreport.
+SELECT 'Q1 eligible' AS check_name,
+       COUNT(DISTINCT p.pmid) AS eligible_pmids,
+       COUNT(DISTINCT CASE WHEN a.pmid IS NULL THEN p.pmid END) AS still_missing
+FROM analysis_summary_article p
+LEFT JOIN reporting_conflicts a ON a.pmid = p.pmid
+WHERE p.articleYear >= 2017
+  AND p.pmid > 0;
+
+-- ---------------------------------------------------------------------------
+-- Q2. The escaping skew -- the tell the issue calls out.
+--
+-- LOAD DATA defaulted to ESCAPED BY '\\', so a backslash in the source text was
+-- consumed as an escape character rather than stored as data. If essentially no
+-- stored statement contains a backslash while a meaningful share contain other
+-- punctuation, the backslashes were eaten. A doubled quote ("") is csv.writer's
+-- escaping leaking through as literal data.
+-- ---------------------------------------------------------------------------
+SELECT 'Q2 escaping skew' AS check_name,
+       COUNT(*)                                                                  AS nonempty_rows,
+       SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%\\\\%')               AS contains_backslash,
+       SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%"%')                  AS contains_quote,
+       SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%""%')                 AS contains_doubled_quote,
+       SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%\t%')                 AS contains_tab,
+       SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%,%')                  AS contains_comma_control
+FROM reporting_conflicts
+WHERE LENGTH(conflictStatement) > 0;
+
+-- ---------------------------------------------------------------------------
+-- Q3. Cross-paper concatenation -- the #87/#89/#88 shape.
+--
+-- COI statements are highly stereotyped. A row where the boilerplate opening
+-- appears two or more times is two papers' text welded together by a desynced
+-- LOAD DATA parse. Occurrence count via the standard length-of-REPLACE idiom.
+-- ---------------------------------------------------------------------------
+SELECT 'Q3 concatenation' AS check_name,
+       COUNT(*) AS suspect_rows
+FROM reporting_conflicts
+WHERE LENGTH(conflictStatement) > 0
+  AND ( CHAR_LENGTH(LOWER(CONVERT(conflictStatement USING utf8mb4)))
+        - CHAR_LENGTH(REPLACE(LOWER(CONVERT(conflictStatement USING utf8mb4)),
+                              'competing interest', ''))
+      ) / CHAR_LENGTH('competing interest') >= 2;
+
+-- The worst offenders, to eyeball. If these read as one coherent statement the
+-- detector is just seeing a wordy disclosure; if they read as two papers, it is real.
+SELECT pmid,
+       LENGTH(conflictStatement) AS blob_bytes,
+       LEFT(CONVERT(conflictStatement USING utf8mb4), 300) AS head_300
+FROM reporting_conflicts
+WHERE LENGTH(conflictStatement) > 0
+  AND ( CHAR_LENGTH(LOWER(CONVERT(conflictStatement USING utf8mb4)))
+        - CHAR_LENGTH(REPLACE(LOWER(CONVERT(conflictStatement USING utf8mb4)),
+                              'competing interest', ''))
+      ) / CHAR_LENGTH('competing interest') >= 2
+ORDER BY LENGTH(conflictStatement) DESC
+LIMIT 10;
+
+-- ---------------------------------------------------------------------------
+-- Q4. Parse-desync tells that need no DynamoDB comparison.
+--
+-- A statement starting lowercase or with punctuation began mid-sentence: the
+-- reader lost the front of the field. A statement that is exactly a numeric
+-- string is a pmid that landed in the text column -- fields shifted by one.
+-- ---------------------------------------------------------------------------
+-- COLLATE utf8mb4_bin is load-bearing on starts_lowercase: the table collation is
+-- utf8mb4_unicode_ci, under which REGEXP '^[a-z]' matches uppercase too and every
+-- healthy row is reported as a desync. Verified against a seeded fixture -- without
+-- the binary collation this counted 7 of 9 rows instead of the 1 that is real.
+SELECT 'Q4 desync tells' AS check_name,
+       SUM(CONVERT(conflictStatement USING utf8mb4) COLLATE utf8mb4_bin REGEXP '^[a-z]') AS starts_lowercase,
+       SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]') AS starts_punctuation,
+       SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[0-9]+$')     AS is_bare_number,
+       MAX(LENGTH(conflictStatement))                                      AS max_blob_bytes,
+       SUM(LENGTH(conflictStatement) >= 65535)                             AS at_blob_ceiling
+FROM reporting_conflicts
+WHERE LENGTH(conflictStatement) > 0;
+
+-- ---------------------------------------------------------------------------
+-- Q5. Truncation against the varchar copy.
+--
+-- conflictsVarchar was written as CAST(conflictStatement AS CHAR(15000)). Rows
+-- where the blob exceeds that are the ones any varchar-based analysis silently
+-- understates -- which is why every check above reads the blob.
+-- ---------------------------------------------------------------------------
+SELECT 'Q5 varchar truncation' AS check_name,
+       SUM(LENGTH(conflictStatement) > 15000) AS blob_exceeds_varchar,
+       SUM(conflictsVarchar IS NULL AND LENGTH(conflictStatement) > 0) AS varchar_never_populated
+FROM reporting_conflicts;

--- a/update/audit_conflicts_selftest.sql
+++ b/update/audit_conflicts_selftest.sql
@@ -46,6 +46,7 @@ INSERT INTO reporting_conflicts (pmid, conflictStatement) VALUES
  (1001, 'The authors have declared that no competing interest exists.'),
  (1002, 'Dr. Smith reports grants from NIH. The other authors declare no competing interest.'),
  (1003, 'The authors declare "no" competing interest. Path: C:\\data\\coi.txt'),
+ (1005, '<b>Conflict of Interest:</b> The authors declare none.'),  -- PubMed's own markup, healthy
  (1004, '');
 
 -- Corrupt rows, one per shape the old path produced.
@@ -58,6 +59,14 @@ INSERT INTO reporting_conflicts (pmid, conflictStatement) VALUES
 
 INSERT INTO reporting_conflicts (pmid, conflictStatement)
   VALUES (2005, CONCAT('competing interest ', REPEAT('x', 16000)));      -- exceeds the varchar copy
+
+-- Contamination pair: one long text under two pmids. Plus 3103, the Elsevier header
+-- that legitimately says "competing interest" twice and must stay unflagged.
+INSERT INTO reporting_conflicts (pmid, conflictStatement) VALUES
+ (3101, CONCAT('Conflicts of Interest: Dr Roe reports grants from NIH. ', REPEAT('y', 1200))),
+ (3102, CONCAT('Conflicts of Interest: Dr Roe reports grants from NIH. ', REPEAT('y', 1200))),
+ (3103, CONCAT('Declaration of Competing Interest The authors declare the following financial ',
+               'interests which may be considered as potential competing interests: ', REPEAT('z', 1200)));
 
 UPDATE reporting_conflicts SET conflictsVarchar = CAST(conflictStatement AS CHAR(15000)) WHERE conflictsVarchar IS NULL;
 
@@ -96,13 +105,25 @@ SELECT 'embedded quotes counted' AS assertion,
           CONCAT('FAIL got ', SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%"%'))) AS result
 FROM reporting_conflicts WHERE LENGTH(conflictStatement) > 0;
 
-SELECT 'cross-paper concatenation detected' AS assertion,
-       IF(COUNT(*) = 1, 'PASS', CONCAT('FAIL got ', COUNT(*))) AS result
-FROM reporting_conflicts
-WHERE LENGTH(conflictStatement) > 0
-  AND ( CHAR_LENGTH(LOWER(CONVERT(conflictStatement USING utf8mb4)))
-        - CHAR_LENGTH(REPLACE(LOWER(CONVERT(conflictStatement USING utf8mb4)), 'competing interest', ''))
-      ) / CHAR_LENGTH('competing interest') >= 2;
+-- Contamination: pmids 3101/3102 share one long text; the Elsevier-boilerplate row
+-- 3103 repeats "competing interest" twice but is a single legitimate statement and
+-- must NOT be flagged. The old repeat-counting heuristic flagged 5,272 rows on the
+-- live table, almost all of them the 3103 shape. That is what this asserts against.
+SELECT 'contamination detected, boilerplate NOT flagged' AS assertion,
+       IF(COUNT(*) = 1 AND SUM(n_pmids) = 2, 'PASS',
+          CONCAT('FAIL texts=', COUNT(*), ' rows=', COALESCE(SUM(n_pmids),0))) AS result
+FROM (SELECT MD5(conflictStatement) AS h, COUNT(DISTINCT pmid) AS n_pmids
+      FROM reporting_conflicts
+      WHERE LENGTH(conflictStatement) > 1000
+      GROUP BY h HAVING COUNT(DISTINCT pmid) > 1) x;
+
+SELECT 'HTML markup start not counted as desync' AS assertion,
+       IF(SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]'
+              AND CONVERT(conflictStatement USING utf8mb4) NOT LIKE '<%') = 1, 'PASS',
+          CONCAT('FAIL got ', SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]'
+                 AND CONVERT(conflictStatement USING utf8mb4) NOT LIKE '<%'),
+                 ' -- PubMed ships <b>Conflict...</b> markup; only the bare-quote row is real')) AS result
+FROM reporting_conflicts WHERE LENGTH(conflictStatement) > 0;
 
 -- The regression this file exists for. Expect 2: the truncated row 2002 and the
 -- oversized row 2005, which also happens to start lowercase. Without the binary
@@ -113,9 +134,14 @@ SELECT 'starts_lowercase is case-SENSITIVE' AS assertion,
                  ' expected 2 -- the ci collation is matching uppercase')) AS result
 FROM reporting_conflicts WHERE LENGTH(conflictStatement) > 0;
 
-SELECT 'field-shift and punctuation-start detected' AS assertion,
+-- The un-excluded form must see BOTH the real bare-quote row and the healthy <b> row.
+-- If this ever equals the excluded form's 1, the fixture lost its HTML row and the
+-- markup exclusion above is passing vacuously.
+SELECT 'field-shift detected; markup exclusion is load-bearing' AS assertion,
        IF(SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[0-9]+$') = 1
-          AND SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]') = 1, 'PASS', 'FAIL') AS result
+          AND SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]') = 2, 'PASS',
+          CONCAT('FAIL bare_number=', SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[0-9]+$'),
+                 ' punct_unexcluded=', SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]'))) AS result
 FROM reporting_conflicts WHERE LENGTH(conflictStatement) > 0;
 
 SELECT 'blob exceeding the varchar copy detected' AS assertion,

--- a/update/audit_conflicts_selftest.sql
+++ b/update/audit_conflicts_selftest.sql
@@ -1,0 +1,124 @@
+-- audit_conflicts_selftest.sql -- proves audit_conflicts.sql actually detects what it claims (#127)
+--
+-- An audit whose detectors have never been shown to fire is worse than no audit:
+-- it reports a clean table and the issue gets closed over real damage. This seeds
+-- known-good and known-corrupt rows and asserts each detector finds exactly them.
+--
+-- It caught a live bug on first run: under the table's utf8mb4_unicode_ci collation
+-- REGEXP '^[a-z]' also matches uppercase, so the starts_lowercase check reported 7
+-- of 9 healthy rows as corrupt. Hence COLLATE utf8mb4_bin in audit_conflicts.sql.
+--
+-- SAFETY: runs entirely inside its own scratch database and never references the
+-- real one. Still, run it against a throwaway server, not production:
+--
+--   docker run -d --name coi-selftest -e MARIADB_ROOT_PASSWORD=t mariadb:11
+--   docker cp audit_conflicts_selftest.sql coi-selftest:/tmp/
+--   docker exec coi-selftest mariadb -uroot -pt -e "SOURCE /tmp/audit_conflicts_selftest.sql"
+--
+-- Every row of output must read PASS.
+
+CREATE DATABASE IF NOT EXISTS audit_conflicts_selftest;
+USE audit_conflicts_selftest;
+
+DROP TABLE IF EXISTS reporting_conflicts;
+DROP TABLE IF EXISTS analysis_summary_article;
+
+-- DDL copied verbatim from setup/createDatabaseTableReciterDb.sql; the collation
+-- is the whole point of the exercise, so it must not be simplified here.
+CREATE TABLE `reporting_conflicts` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `pmid` int(11) DEFAULT NULL,
+  `conflictStatement` blob DEFAULT NULL,
+  `conflictsVarchar` varchar(15000) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_pmid` (`pmid`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE `analysis_summary_article` (
+  `pmid` int(11) DEFAULT 0,
+  `articleYear` int(11) DEFAULT 0,
+  KEY `z` (`pmid`) USING BTREE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Healthy rows, including the poison content the old LOAD DATA path mangled and
+-- the new executemany path stores verbatim. None of these may be flagged.
+INSERT INTO reporting_conflicts (pmid, conflictStatement) VALUES
+ (1001, 'The authors have declared that no competing interest exists.'),
+ (1002, 'Dr. Smith reports grants from NIH. The other authors declare no competing interest.'),
+ (1003, 'The authors declare "no" competing interest. Path: C:\\data\\coi.txt'),
+ (1004, '');
+
+-- Corrupt rows, one per shape the old path produced.
+INSERT INTO reporting_conflicts (pmid, conflictStatement) VALUES
+ (2001, 'The authors declare no competing interest exists. The authors report no competing interest for this second unrelated paper.'),  -- two papers welded (#87/#89/#88)
+ (2002, 'ports personal fees from Pfizer outside the submitted work.'),  -- front of field lost
+ (2003, '38112233'),                                                     -- pmid landed in the text column
+ (2004, '" competing interest disclosed by the corresponding author.'),  -- starts on the enclosure char
+ (1001, 'The authors have declared that no competing interest exists.'); -- duplicate pmid (no UNIQUE key here)
+
+INSERT INTO reporting_conflicts (pmid, conflictStatement)
+  VALUES (2005, CONCAT('competing interest ', REPEAT('x', 16000)));      -- exceeds the varchar copy
+
+UPDATE reporting_conflicts SET conflictsVarchar = CAST(conflictStatement AS CHAR(15000)) WHERE conflictsVarchar IS NULL;
+
+-- 9001 is pre-2017; -7 is the reporting SP's synthetic external_article pmid; 0 is the column default.
+-- All three must be excluded from the eligible population. 3001 is eligible but unimported.
+INSERT INTO analysis_summary_article (pmid, articleYear) VALUES
+ (1001,2020),(1002,2021),(1003,2022),(1004,2019),(2001,2018),(2002,2020),
+ (2003,2021),(2004,2022),(2005,2023),(3001,2024),(9001,2005),(-7,2023),(0,2023);
+
+-- ---------------------------------------------------------------------------
+-- Assertions. Expected values are the seeded truth, counted by hand above.
+-- ---------------------------------------------------------------------------
+SELECT 'duplicate pmid detected' AS assertion,
+       IF(COUNT(*) - COUNT(DISTINCT pmid) = 1, 'PASS', CONCAT('FAIL got ', COUNT(*) - COUNT(DISTINCT pmid))) AS result
+FROM reporting_conflicts;
+
+SELECT 'synthetic/negative/old pmids excluded' AS assertion,
+       IF(COUNT(DISTINCT p.pmid) = 10, 'PASS', CONCAT('FAIL got ', COUNT(DISTINCT p.pmid))) AS result
+FROM analysis_summary_article p
+WHERE p.articleYear >= 2017 AND p.pmid > 0;
+
+SELECT 'unimported pmid detected, join fanout not miscounted' AS assertion,
+       IF(COUNT(DISTINCT CASE WHEN a.pmid IS NULL THEN p.pmid END) = 1, 'PASS',
+          CONCAT('FAIL got ', COUNT(DISTINCT CASE WHEN a.pmid IS NULL THEN p.pmid END))) AS result
+FROM analysis_summary_article p
+LEFT JOIN reporting_conflicts a ON a.pmid = p.pmid
+WHERE p.articleYear >= 2017 AND p.pmid > 0;
+
+SELECT 'backslash survives verbatim' AS assertion,
+       IF(SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%\\\\%') = 1, 'PASS',
+          CONCAT('FAIL got ', SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%\\\\%'))) AS result
+FROM reporting_conflicts WHERE LENGTH(conflictStatement) > 0;
+
+SELECT 'embedded quotes counted' AS assertion,
+       IF(SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%"%') = 2, 'PASS',
+          CONCAT('FAIL got ', SUM(CONVERT(conflictStatement USING utf8mb4) LIKE '%"%'))) AS result
+FROM reporting_conflicts WHERE LENGTH(conflictStatement) > 0;
+
+SELECT 'cross-paper concatenation detected' AS assertion,
+       IF(COUNT(*) = 1, 'PASS', CONCAT('FAIL got ', COUNT(*))) AS result
+FROM reporting_conflicts
+WHERE LENGTH(conflictStatement) > 0
+  AND ( CHAR_LENGTH(LOWER(CONVERT(conflictStatement USING utf8mb4)))
+        - CHAR_LENGTH(REPLACE(LOWER(CONVERT(conflictStatement USING utf8mb4)), 'competing interest', ''))
+      ) / CHAR_LENGTH('competing interest') >= 2;
+
+-- The regression this file exists for. Expect 2: the truncated row 2002 and the
+-- oversized row 2005, which also happens to start lowercase. Without the binary
+-- collation this returns 7, i.e. nearly every healthy row.
+SELECT 'starts_lowercase is case-SENSITIVE' AS assertion,
+       IF(SUM(CONVERT(conflictStatement USING utf8mb4) COLLATE utf8mb4_bin REGEXP '^[a-z]') = 2, 'PASS',
+          CONCAT('FAIL got ', SUM(CONVERT(conflictStatement USING utf8mb4) COLLATE utf8mb4_bin REGEXP '^[a-z]'),
+                 ' expected 2 -- the ci collation is matching uppercase')) AS result
+FROM reporting_conflicts WHERE LENGTH(conflictStatement) > 0;
+
+SELECT 'field-shift and punctuation-start detected' AS assertion,
+       IF(SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[0-9]+$') = 1
+          AND SUM(CONVERT(conflictStatement USING utf8mb4) REGEXP '^[[:punct:]]') = 1, 'PASS', 'FAIL') AS result
+FROM reporting_conflicts WHERE LENGTH(conflictStatement) > 0;
+
+SELECT 'blob exceeding the varchar copy detected' AS assertion,
+       IF(SUM(LENGTH(conflictStatement) > 15000) = 1, 'PASS',
+          CONCAT('FAIL got ', SUM(LENGTH(conflictStatement) > 15000))) AS result
+FROM reporting_conflicts;

--- a/update/conflictsImport.py
+++ b/update/conflictsImport.py
@@ -1,164 +1,361 @@
+# conflictsImport.py
+
 import boto3
-import csv
 import logging
 import pymysql.cursors
 import pymysql.err
+import random
 import sys
 import time
-import os  # Import the os module
+import os
+import concurrent.futures
 
-# Delete the existing conflicts.csv file if it exists
-if os.path.exists('conflicts.csv'):
-    os.remove('conflicts.csv')
+# ------------------------------------------------------------------------------
+# Logging
+# ------------------------------------------------------------------------------
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
 
-# Configure logging to output to stdout
-logging.basicConfig(stream=sys.stdout, level=logging.INFO, format='%(asctime)s - %(message)s')
+# Quiet botocore's per-call credential/endpoint chatter so pipeline logs stay readable.
+logging.getLogger("botocore").setLevel(logging.WARNING)
+logging.getLogger("boto3").setLevel(logging.WARNING)
 
-DB_USERNAME = os.getenv('DB_USERNAME')
-DB_PASSWORD = os.getenv('DB_PASSWORD')
-DB_HOST = os.getenv('DB_HOST')
-DB_NAME = os.getenv('DB_NAME')
+# ------------------------------------------------------------------------------
+# Environment Variables
+# ------------------------------------------------------------------------------
+DB_USERNAME = os.getenv("DB_USERNAME")
+DB_PASSWORD = os.getenv("DB_PASSWORD")
+DB_HOST = os.getenv("DB_HOST")
+DB_NAME = os.getenv("DB_NAME")
 
-def connect_mysql_server(DB_USERNAME, DB_PASSWORD, DB_HOST, DB_NAME):
-    """Function to connect to MySQL database"""
+# ------------------------------------------------------------------------------
+# Settings
+# ------------------------------------------------------------------------------
+# DynamoDB fetch
+CHUNK_SIZE = 100              # Max keys per batch_get_item call (DynamoDB hard limit)
+MAX_WORKERS = 5               # Threads for parallel fetching
+MAX_UNPROCESSED_RETRIES = 8   # Backoff retries for keys DynamoDB reports as unprocessed
+
+# Insert
+INSERT_BATCH_SIZE = 200       # Rows per executemany batch (kept well under max_allowed_packet)
+
+# Scope. COI statements are only collected for recent articles; this preserves
+# the filter the importer has always used. Widening it would backfill decades
+# of articles on the next nightly run.
+MIN_ARTICLE_YEAR = 2017
+
+# Loop safety
+MAX_CYCLES = 25               # Hard cap on fetch/insert cycles; a healthy run needs 1-2
+
+# Dry run
+DRY_RUN = "--dry-run" in sys.argv
+DRY_RUN_SAMPLE = 500          # PMIDs processed when --dry-run is passed
+DRY_RUN_TABLE = "reporting_conflicts_dryrun"
+
+
+# ------------------------------------------------------------------------------
+# Database Connection
+# ------------------------------------------------------------------------------
+def connect_mysql_server(db_user, db_pass, db_host, db_name):
+    """Connect to the MariaDB database."""
     try:
-        mysql_db = pymysql.connect(user=DB_USERNAME,
-                                   password=DB_PASSWORD,
-                                   database=DB_NAME,
-                                   host=DB_HOST,
-                                   autocommit=True,
-                                   local_infile=True,
-                                   cursorclass=pymysql.cursors.DictCursor)  # Use DictCursor to fetch results as dictionaries
-        logging.info(f"Connected to database server: {DB_HOST}, database: {DB_NAME}, with user: {DB_USERNAME}")
+        mysql_db = pymysql.connect(
+            user=db_user,
+            password=db_pass,
+            database=db_name,
+            host=db_host,
+            autocommit=True,
+            charset="utf8mb4",
+            cursorclass=pymysql.cursors.DictCursor
+        )
+        logger.info(f"Connected to database server: {db_host}, database: {db_name}, user: {db_user}")
         return mysql_db
     except pymysql.err.MySQLError as err:
-        logging.error(f"{time.ctime()} -- Error connecting to the database: {err}")
+        logger.error(f"{time.ctime()} -- Error connecting to the database: {err}")
+        sys.exit(1)
 
-# Connect to MySQL
-mysql_conn = connect_mysql_server(DB_USERNAME, DB_PASSWORD, DB_HOST, DB_NAME)
 
-# Query for PMIDs
-with mysql_conn.cursor() as mysql_cursor:
-    mysql_cursor.execute('''
-        SELECT distinct p.pmid AS pmid
+# ------------------------------------------------------------------------------
+# Fetch All Missing PMIDs
+# ------------------------------------------------------------------------------
+def fetch_missing_pmids(mysql_conn):
+    """
+    Returns every PMID that exists in analysis_summary_article but has no
+    matching row in reporting_conflicts.
+
+    `p.pmid > 0` is load-bearing: STEP 6b of the reporting SP injects one row per
+    external_article (Scopus/WOS/OpenAlex) under a synthetic NEGATIVE pmid, and
+    analysis_summary_article.pmid is itself nullable with DEFAULT 0. Neither has a
+    PubMedArticle record, so without this guard they are reported as missing on
+    every run forever and the no-progress warning below fires unconditionally.
+    """
+    sql = """
+        SELECT DISTINCT p.pmid AS pmid
         FROM analysis_summary_article p
         LEFT JOIN reporting_conflicts a ON a.pmid = p.pmid
-        WHERE a.pmid is null
-        and articleYear >= 2017
-        and p.pmid > 0
-        LIMIT 90
-    ''')
-    results = mysql_cursor.fetchall()
-    pmids = [result['pmid'] for result in results]  # Use dictionary key to access pmid
+        WHERE a.pmid IS NULL
+          AND p.articleYear >= %s
+          AND p.pmid > 0
+    """
+    with mysql_conn.cursor() as cursor:
+        cursor.execute(sql, (MIN_ARTICLE_YEAR,))
+        return [row["pmid"] for row in cursor.fetchall()]
 
 
-
-# Connect to DynamoDB
-dynamodb = boto3.resource('dynamodb')
-table = dynamodb.Table('PubMedArticle')
-
-# Use client for batch get 
-client = dynamodb.meta.client
-keys = [{'pmid': pmid} for pmid in pmids]
-
-# Check if keys is empty before making the call
-if not keys:
-    logging.warning("No PMIDs found to fetch from DynamoDB.")
-    exit()
-else:
-    response = client.batch_get_item(RequestItems={
-      'PubMedArticle': {
-          'Keys': keys
-      }
-    })
-    items = response['Responses']['PubMedArticle']
-
-
-response = client.batch_get_item(RequestItems={
-  'PubMedArticle': {
-      'Keys': keys
-  }
-})
-
-items = response['Responses']['PubMedArticle']
-
-
+# ------------------------------------------------------------------------------
+# Extract COI Statement
+# ------------------------------------------------------------------------------
 def get_conflicts(item):
-    medline_citation = item.get('pubmedarticle', {}).get('medlinecitation')
-    if medline_citation:
-        return medline_citation.get('coiStatement', "")
-    return ""
+    """
+    Extracts the conflict-of-interest statement from a DynamoDB item
+    representing a PubMed article. Returns "" when none is present -- an empty
+    row still has to be written, otherwise the PMID stays "missing" forever and
+    every subsequent run re-fetches it.
+    """
+    medline_citation = item.get("pubmedarticle", {}).get("medlinecitation")
+    if not medline_citation:
+        return ""
+    return medline_citation.get("coiStatement") or ""
 
 
+# ------------------------------------------------------------------------------
+# Fetch COI Statements from DynamoDB
+# ------------------------------------------------------------------------------
+def fetch_conflicts_for_chunk(chunk_pmids):
+    """
+    Fetches one chunk of PMIDs from DynamoDB via batch_get_item. Any keys that
+    DynamoDB reports as unprocessed (throttling) are retried with exponential
+    backoff so they are not silently lost. Returns (pmid, conflictStatement) pairs.
+    """
+    client = boto3.resource("dynamodb").meta.client
 
-# Initial CSV setup
-with open('conflicts.csv', 'w', newline='', encoding='utf-8') as f:
-    writer = csv.writer(f, delimiter='\t')  # specify tab delimiter here
-    writer.writerow(['pmid', 'conflictStatement'])
+    request_keys = [{"pmid": pmid} for pmid in chunk_pmids]
+    results = []
+    attempt = 0
 
-offset = 0 
-limit = 90
+    while request_keys:
+        response = client.batch_get_item(
+            RequestItems={"PubMedArticle": {"Keys": request_keys}}
+        )
 
-while True:
-    logging.info(f'Processing offset: {offset}')  # Log the current offset
+        for item in response["Responses"].get("PubMedArticle", []):
+            pmid = item.get("pmid")
+            if pmid is not None:
+                results.append((pmid, get_conflicts(item)))
 
-    mysql_cursor = mysql_conn.cursor()
-    mysql_cursor.execute('''
-        SELECT distinct p.pmid AS pmid
-        FROM analysis_summary_article p
-        LEFT JOIN reporting_conflicts a ON a.pmid = p.pmid
-        WHERE a.pmid is null
-        and articleYear >= 2017
-        and p.pmid > 0
-        LIMIT %s OFFSET %s
-    ''', (limit, offset))
+        request_keys = (
+            response.get("UnprocessedKeys", {})
+            .get("PubMedArticle", {})
+            .get("Keys", [])
+        )
+        if request_keys:
+            attempt += 1
+            if attempt > MAX_UNPROCESSED_RETRIES:
+                logger.warning(
+                    f"{len(request_keys)} key(s) still unprocessed after "
+                    f"{MAX_UNPROCESSED_RETRIES} retries; skipping this chunk's remainder."
+                )
+                break
+            time.sleep(min(0.1 * (2 ** attempt), 5.0))
 
-    results = mysql_cursor.fetchall()
+    return results
 
+
+def fetch_all_conflicts(pmids):
+    """Fetches COI statements for all given PMIDs from DynamoDB in parallel."""
+    chunks = [pmids[i:i + CHUNK_SIZE] for i in range(0, len(pmids), CHUNK_SIZE)]
+    logger.info(f"Created {len(chunks)} chunk(s). Each chunk up to {CHUNK_SIZE} PMIDs.")
+
+    all_results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+        futures = {executor.submit(fetch_conflicts_for_chunk, c): c for c in chunks}
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                all_results.extend(future.result())
+            except Exception as e:
+                logger.exception(f"Error fetching chunk: {e}")
+    return all_results
+
+
+# ------------------------------------------------------------------------------
+# Insert COI Statements
+# ------------------------------------------------------------------------------
+def insert_conflicts(mysql_conn, results, target_table="reporting_conflicts"):
+    """
+    Inserts (pmid, conflictStatement) pairs with a parameterized, batched INSERT.
+
+    pymysql binds every value as a query parameter, so COI statements containing
+    double quotes, tabs, newlines or backslashes are stored verbatim. The
+    previous CSV + LOAD DATA INFILE path could not parse such content and
+    silently dropped or concatenated the affected rows -- the same defect that
+    was removed from abstractImport.py.
+    """
     if not results:
-        logging.info('No more results, breaking out of loop')  # Log the end condition
-        break
+        logger.info("No conflict statements to insert.")
+        return 0
 
-    pmids = [result['pmid'] for result in results]
+    insert_sql = f"INSERT INTO {target_table} (pmid, conflictStatement) VALUES (%s, %s)"
+    inserted = 0
+    with mysql_conn.cursor() as cursor:
+        for i in range(0, len(results), INSERT_BATCH_SIZE):
+            batch = results[i:i + INSERT_BATCH_SIZE]
+            cursor.executemany(insert_sql, batch)
+            inserted += len(batch)
+        logger.info(f"{time.ctime()} -- Inserted {inserted} row(s) into {target_table}.")
 
-    logging.info(f'Fetching data for {len(pmids)} PMIDs from DynamoDB')  # Log the number of PMIDs
-
-    keys = [{'pmid': pmid} for pmid in pmids]
-    response = client.batch_get_item(RequestItems={'PubMedArticle': {'Keys': keys}})
-    items = response['Responses']['PubMedArticle']
-
-    for item in items:
-        conflictStatement = get_conflicts(item)
-        with open('conflicts.csv', 'a', newline='', encoding='utf-8') as f:
-            writer = csv.writer(f, delimiter='\t')  # specify tab delimiter here
-            writer.writerow([item['pmid'], conflictStatement])
-
-    offset += limit
-
-
-def load_conflicts(mysql_cursor):
-    cwd = os.getcwd()
-    load_conflicts_query = (
-        "LOAD DATA LOCAL INFILE '" + cwd + "/conflicts.csv' INTO TABLE reporting_conflicts FIELDS TERMINATED BY '\t' ENCLOSED BY '\"' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (pmid,conflictStatement);"
-    )
-    mysql_cursor.execute(load_conflicts_query)
-    print(time.ctime() + "--" + " conflicts.csv file loaded")
-
-    update_query = (
-      "UPDATE reporting_conflicts SET conflictsVarchar = CAST(conflictStatement AS CHAR(15000)) where conflictsVarchar is null;"
-    )
-    
-    mysql_cursor.execute(update_query)
-    print(time.ctime() + " reporting_conflicts table updated with varchar equivalent")  
+        cursor.execute(
+            f"UPDATE {target_table} "
+            f"SET conflictsVarchar = CAST(conflictStatement AS CHAR(15000)) "
+            f"WHERE conflictsVarchar IS NULL"
+        )
+        logger.info(f"{time.ctime()} -- {target_table} updated with varchar equivalents.")
+    return inserted
 
 
-if __name__ == '__main__':
+# ------------------------------------------------------------------------------
+# Dry Run
+# ------------------------------------------------------------------------------
+def run_dry_run(mysql_conn):
+    """
+    Verifies the fetch -> insert path end to end without modifying
+    reporting_conflicts: a random sample of missing PMIDs is processed into a
+    session-private TEMPORARY table, then verified and discarded.
+    """
+    logger.info("=== DRY RUN === reporting_conflicts will NOT be modified.")
 
-    # Create a MySQL connection to the Reciter database
-    reciter_db = connect_mysql_server(DB_USERNAME, DB_PASSWORD, DB_HOST, DB_NAME)
-    with reciter_db.cursor() as reciter_db_cursor:
-        load_conflicts(reciter_db_cursor)
+    all_pmids = fetch_missing_pmids(mysql_conn)
+    logger.info(f"{len(all_pmids)} PMID(s) currently missing conflict statements in production.")
+    if not all_pmids:
+        logger.info("Nothing missing; no sample to process.")
+        mysql_conn.close()
+        return
 
-    # Close DB connection
-    reciter_db.close()
+    sample = random.sample(all_pmids, min(DRY_RUN_SAMPLE, len(all_pmids)))
+    logger.info(f"Processing a random sample of {len(sample)} PMID(s) through the new insert path.")
 
+    try:
+        with mysql_conn.cursor() as cursor:
+            cursor.execute(f"CREATE TEMPORARY TABLE {DRY_RUN_TABLE} LIKE reporting_conflicts")
+
+        all_results = fetch_all_conflicts(sample)
+        logger.info(f"Fetched {len(all_results)} item(s) from DynamoDB (requested {len(sample)}).")
+        if not all_results:
+            logger.error("DRY RUN FAILED: DynamoDB returned nothing for the sample.")
+            return
+
+        poison = [
+            (p, c) for p, c in all_results
+            if c and any(ch in c for ch in ('"', '\t', '\n', '\r', '\\'))
+        ]
+        logger.info(
+            f"{len(poison)} of {len(all_results)} fetched statements contain "
+            f"quotes/tabs/newlines/backslashes -- the content the old LOAD DATA "
+            f"path silently dropped."
+        )
+        if poison:
+            logger.info(f"Example poison statement (PMID {poison[0][0]}): {poison[0][1][:160]!r}")
+
+        inserted = insert_conflicts(mysql_conn, all_results, target_table=DRY_RUN_TABLE)
+
+        with mysql_conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT COUNT(*) c, COUNT(DISTINCT pmid) d, "
+                f"SUM(pmid IS NULL) nullp, SUM(conflictsVarchar IS NULL) nullv "
+                f"FROM {DRY_RUN_TABLE}"
+            )
+            stats = cursor.fetchone()
+
+        # An empty COI statement casts to '' rather than NULL, so nullv should be
+        # 0 even for the many articles that carry no statement at all.
+        counts_ok = (
+            stats["c"] == len(all_results)
+            and not stats["nullp"]
+            and not stats["nullv"]
+        )
+
+        # Content-integrity check: re-read the longest poison statement verbatim.
+        integrity_ok = True
+        if poison:
+            worst_pmid, worst_text = max(poison, key=lambda x: len(x[1]))
+            with mysql_conn.cursor() as cursor:
+                cursor.execute(
+                    f"SELECT conflictStatement FROM {DRY_RUN_TABLE} WHERE pmid = %s", (worst_pmid,)
+                )
+                stored = cursor.fetchone()["conflictStatement"]
+            if isinstance(stored, bytes):
+                stored = stored.decode("utf-8")
+            integrity_ok = (stored == worst_text)
+            logger.info(
+                f"Content-integrity check on PMID {worst_pmid} "
+                f"({len(worst_text)} chars, contains poison characters): "
+                f"{'MATCH' if integrity_ok else 'MISMATCH'}"
+            )
+
+        if counts_ok and integrity_ok:
+            logger.info(
+                f"DRY RUN PASSED -- {inserted} row(s) inserted; {stats['c']} present; "
+                f"{stats['d']} distinct PMIDs; 0 NULL pmids; 0 NULL conflictsVarchar; "
+                f"content stored verbatim."
+            )
+        else:
+            logger.error(
+                f"DRY RUN FAILED -- rows={stats['c']} (expected {len(all_results)}); "
+                f"null_pmid={stats['nullp']}; null_varchar={stats['nullv']}; "
+                f"integrity_ok={integrity_ok}"
+            )
+    finally:
+        with mysql_conn.cursor() as cursor:
+            cursor.execute(f"DROP TEMPORARY TABLE IF EXISTS {DRY_RUN_TABLE}")
+        logger.info(f"Scratch table {DRY_RUN_TABLE} dropped.")
+        mysql_conn.close()
+
+
+# ------------------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------------------
+def main():
+    mysql_conn = connect_mysql_server(DB_USERNAME, DB_PASSWORD, DB_HOST, DB_NAME)
+
+    if DRY_RUN:
+        run_dry_run(mysql_conn)
+        return
+
+    prev_missing = None
+    for cycle in range(1, MAX_CYCLES + 1):
+        all_pmids = fetch_missing_pmids(mysql_conn)
+        if not all_pmids:
+            logger.info("No more missing conflict statements. We are done.")
+            break
+
+        logger.info(f"Cycle {cycle}: found {len(all_pmids)} PMID(s) needing conflict statements.")
+
+        # Safety net: if a cycle does not reduce the missing count, the
+        # remaining PMIDs cannot be resolved (no DynamoDB record). Stop rather
+        # than loop forever -- the failure mode that hung the nightly pipeline.
+        if prev_missing is not None and len(all_pmids) >= prev_missing:
+            logger.warning(
+                f"No progress since the previous cycle ({len(all_pmids)} PMID(s) "
+                f"still missing); stopping. These PMIDs have no retrievable record."
+            )
+            break
+        prev_missing = len(all_pmids)
+
+        all_results = fetch_all_conflicts(all_pmids)
+        logger.info(f"Fetched conflict statements for {len(all_results)} PMID(s) from DynamoDB.")
+        insert_conflicts(mysql_conn, all_results)
+    else:
+        logger.warning(
+            f"Reached the {MAX_CYCLES}-cycle safety limit with conflict statements "
+            f"still missing; stopping. A healthy run converges in 1-2 cycles -- investigate."
+        )
+
+    mysql_conn.close()
+    logger.info("Conflict statement import complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/update/conflictsImport.py
+++ b/update/conflictsImport.py
@@ -56,6 +56,9 @@ DRY_RUN = "--dry-run" in sys.argv
 DRY_RUN_SAMPLE = 500          # PMIDs processed when --dry-run is passed
 DRY_RUN_TABLE = "reporting_conflicts_dryrun"
 
+# Refresh pass (#130). Combines with --dry-run to report without writing.
+REFRESH_EMPTY = "--refresh-empty" in sys.argv
+
 
 # ------------------------------------------------------------------------------
 # Database Connection
@@ -217,6 +220,69 @@ def insert_conflicts(mysql_conn, results, target_table="reporting_conflicts"):
 
 
 # ------------------------------------------------------------------------------
+# Refresh Empty Statements (#130)
+# ------------------------------------------------------------------------------
+def refresh_empty_statements(mysql_conn):
+    """
+    Re-checks rows that exist but hold an empty statement, and fills the ones
+    DynamoDB now has content for.
+
+    The nightly backfill cannot do this. It selects work with
+    `LEFT JOIN ... WHERE a.pmid IS NULL`, and an article with no coiStatement at
+    import time still gets a row written (deliberately -- otherwise the PMID stays
+    "missing" forever and the importer never converges). So the row exists, is
+    never selected again, and any statement PubMed adds in a later record revision
+    stays invisible. Measured at ~5,100 affected rows on 2026-07-28.
+
+    Deliberately does NOT touch rows that already have a statement. Refreshing
+    those means overwriting curated-looking production text on the strength of a
+    single upstream read, and the audit put that class at only ~0.85%. Fill-only
+    is the safe half; revisit the other half separately if it turns out to matter.
+    """
+    with mysql_conn.cursor() as cursor:
+        cursor.execute(
+            "SELECT pmid FROM reporting_conflicts "
+            "WHERE pmid > 0 AND LENGTH(conflictStatement) = 0"
+        )
+        pmids = [row["pmid"] for row in cursor.fetchall()]
+
+    logger.info(f"{len(pmids)} row(s) currently hold an empty conflict statement.")
+    if not pmids:
+        logger.info("Nothing to refresh.")
+        return 0
+
+    results = fetch_all_conflicts(pmids)
+    logger.info(f"Re-fetched {len(results)} of {len(pmids)} from DynamoDB.")
+
+    filled = [(text, text, pmid) for pmid, text in results if text]
+    logger.info(f"{len(filled)} now have a statement upstream.")
+    if not filled:
+        return 0
+
+    if DRY_RUN:
+        for text, _, pmid in filled[:3]:
+            logger.info(f"  would fill PMID {pmid}: {text[:120]!r}")
+        logger.info(f"=== DRY RUN === {len(filled)} row(s) would be filled; nothing written.")
+        return 0
+
+    # `AND LENGTH(conflictStatement) = 0` is the data-loss guard: even if the set
+    # went stale between the SELECT and here, this can only ever fill an empty
+    # statement, never overwrite one. Do not drop it.
+    update_sql = (
+        "UPDATE reporting_conflicts "
+        "SET conflictStatement = %s, conflictsVarchar = CAST(%s AS CHAR(15000)) "
+        "WHERE pmid = %s AND LENGTH(conflictStatement) = 0"
+    )
+    updated = 0
+    with mysql_conn.cursor() as cursor:
+        for i in range(0, len(filled), INSERT_BATCH_SIZE):
+            cursor.executemany(update_sql, filled[i:i + INSERT_BATCH_SIZE])
+            updated += cursor.rowcount   # actual rows changed, not rows attempted
+    logger.info(f"{time.ctime()} -- Filled {updated} previously-empty statement(s).")
+    return updated
+
+
+# ------------------------------------------------------------------------------
 # Dry Run
 # ------------------------------------------------------------------------------
 def run_dry_run(mysql_conn):
@@ -319,6 +385,16 @@ def run_dry_run(mysql_conn):
 # ------------------------------------------------------------------------------
 def main():
     mysql_conn = connect_mysql_server(DB_USERNAME, DB_PASSWORD, DB_HOST, DB_NAME)
+
+    # Checked before DRY_RUN so `--refresh-empty --dry-run` reports the refresh
+    # rather than falling into the insert-path dry run.
+    if REFRESH_EMPTY:
+        try:
+            refresh_empty_statements(mysql_conn)
+        finally:
+            mysql_conn.close()
+        logger.info("Refresh pass complete.")
+        return
 
     if DRY_RUN:
         run_dry_run(mysql_conn)

--- a/update/run_all.py
+++ b/update/run_all.py
@@ -129,6 +129,29 @@ def run_scopus_lane_if_due():
         logger.exception(f"Scopus lane failed (ignored — reporting unaffected): {e}")
 
 
+# ------------- COI refresh pass (weekly, isolated) -------------
+def run_conflicts_refresh_if_due():
+    """Weekly refill of reporting_conflicts rows that exist but are empty (#130).
+
+    The nightly conflictsImport backfill selects on `a.pmid IS NULL`, so a row
+    written empty (no coiStatement upstream at import time) is never revisited and
+    a statement PubMed adds later stays invisible -- ~5,100 rows when measured.
+
+    Weekly, not nightly: COI statements accrue over months, and a full pass re-reads
+    ~87k pmids from DynamoDB. Isolated like the AAR lanes -- any failure is caught
+    and logged so it can NEVER fail the nightly, since this only ever adds data that
+    was missing and is safe to skip until next week."""
+    try:
+        import datetime as _datetime
+        if _datetime.datetime.utcnow().weekday() != 6:   # 6 = Sunday
+            logger.info("COI refresh: not due (runs weekly on Sundays) — skipped")
+            return
+        run_script("conflictsRefresh", "python3 conflictsImport.py --refresh-empty",
+                   timeout_seconds=int(os.getenv("CONFLICTS_REFRESH_TIMEOUT_SECONDS", "3600")))
+    except Exception as e:
+        logger.exception(f"COI refresh failed (ignored — reporting unaffected): {e}")
+
+
 # ------------- AAR PubMed lane (weekly, isolated) -------------
 def run_pubmed_lane_if_due():
     """Weekly PubMed orphan-authorship detector + IO/FB scoring (AAR).
@@ -204,6 +227,7 @@ def main():
     if overall_success:
         run_scopus_lane_if_due()              # weekly (Sun): AAR Scopus lane
         run_pubmed_lane_if_due()              # weekly (Sun): AAR PubMed lane
+        run_conflicts_refresh_if_due()        # weekly (Sun): refill empty COI rows (#130)
 
     upload_log_to_s3()
 

--- a/update/test_conflicts_import.py
+++ b/update/test_conflicts_import.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Regression test for conflictsImport.py -- see issue #127.
+
+Two things this locks down:
+
+1. The CSV + LOAD DATA LOCAL INFILE pairing must stay gone. csv.writer escapes an
+   embedded quote by doubling it; LOAD DATA with no ESCAPED BY clause defaults to
+   ESCAPED BY '\\'. The two disagree on exactly the content COI statements carry,
+   and LOAD DATA reports a desynced parse as a *warning*, so rows are dropped or
+   concatenated with a zero exit code. That is what cost ~99.9% of reporting_abstracts
+   in May 2026 (#78/#80, #87/#89/#88).
+
+2. get_conflicts() must return "" -- never None, never raise -- for every degenerate
+   DynamoDB item shape. An article with no COI statement still has to produce a row,
+   otherwise `LEFT JOIN reporting_conflicts ... WHERE a.pmid IS NULL` returns that
+   PMID forever and the importer never converges.
+
+Run: python3 test_conflicts_import.py
+"""
+import os
+
+from conflictsImport import get_conflicts
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _citation(**kw):
+    return {"pubmedarticle": {"medlinecitation": kw}}
+
+
+def test_no_csv_bulk_load_pattern():
+    # Applied to both importers: they load free text from the same DynamoDB table
+    # and were both written against the same broken template.
+    # Code-only tokens: each of these is unreachable in a comment describing the
+    # old bug, so the guard does not fire on the prose that explains itself.
+    for name in ("conflictsImport.py", "abstractImport.py"):
+        with open(os.path.join(HERE, name), encoding="utf-8") as f:
+            src = f.read()
+        for banned in ("LOAD DATA LOCAL INFILE", "csv.writer", "local_infile"):
+            assert banned not in src, f"{name} reintroduced the banned pattern: {banned!r}"
+        # Repo-wide invariant, and the one the rewrite actually got wrong first
+        # time: the SP injects synthetic NEGATIVE pmids for external_article rows,
+        # which have no PubMedArticle record and would be "missing" forever.
+        assert "p.pmid > 0" in src, f"{name} dropped the `p.pmid > 0` guard"
+
+
+def test_get_conflicts_returns_statement_verbatim():
+    # The exact content class the old LOAD DATA path could not parse.
+    poison = 'The authors declare "no" competing interests.\tPath: C:\\temp\r\nSigned.'
+    assert get_conflicts(_citation(coiStatement=poison)) == poison
+
+
+def test_get_conflicts_never_returns_none():
+    # Each of these was observed or is trivially reachable in the PubMedArticle table.
+    for item in (
+        {},                                        # empty item
+        {"pubmedarticle": {}},                     # no medlinecitation key
+        {"pubmedarticle": {"medlinecitation": None}},   # NULL-serialized sub-object
+        _citation(),                               # citation present, no coiStatement
+        _citation(coiStatement=None),              # coiStatement explicitly NULL
+        _citation(coiStatement=""),                # present but empty
+    ):
+        assert get_conflicts(item) == "", f"expected '' for {item!r}, got {get_conflicts(item)!r}"
+
+
+if __name__ == "__main__":
+    test_no_csv_bulk_load_pattern()
+    test_get_conflicts_returns_statement_verbatim()
+    test_get_conflicts_never_returns_none()
+    print("OK: no CSV bulk-load pattern; COI statements extracted verbatim, never None")


### PR DESCRIPTION
Closes #127.

`update/conflictsImport.py` still used the `csv.writer` + `LOAD DATA LOCAL INFILE` pairing that #78/#80 removed from `update/abstractImport.py` in May 2026 after it silently dropped ~99.9% of `reporting_abstracts` rows. It runs on every nightly and loads free-text COI statements, which routinely contain double quotes and backslashes.

`csv.writer` escapes an embedded quote by doubling it. `LOAD DATA` with no `ESCAPED BY` clause defaults to `ESCAPED BY '\'`. The two disagree on escaping for exactly the content class COI statements contain, and `LOAD DATA` reports a desynced parse as a **warning**, not an error — so rows are dropped or concatenated behind a zero exit code.

## What changed

`conflictsImport.py` is rewritten to mirror `abstractImport.py`, which is already proven in production against the identical defect. Deliberately a near-verbatim port rather than a fresh design, so the two nightly importers can be diffed against each other:

- Parameterized, batched `cursor.executemany` (`INSERT_BATCH_SIZE = 200`) replaces the CSV round-trip. pymysql binds every value, so quotes/tabs/newlines/backslashes are stored verbatim.
- `conflicts.csv` is gone entirely, as is `local_infile=True` on the connection.
- Parallel chunked `batch_get_item` with a **bounded** `UnprocessedKeys` retry (`MAX_UNPROCESSED_RETRIES = 8`, exponential backoff) — previously unprocessed keys were silently lost.
- `MAX_CYCLES` cap plus the no-progress safety net, so unresolvable PMIDs stop the loop instead of hanging the nightly.
- Removed the duplicated `LIMIT 90` query and `batch_get_item` that ran at **module import** time, and the module-level `exit()`.

Preserved deliberately: the `articleYear >= 2017` scope filter (widening it would backfill decades of articles on the next nightly) and the `p.pmid > 0` guard, which keeps the reporting SP's synthetic negative pmids for `external_article` rows out of the DynamoDB fetch.

An article with no `coiStatement` still gets a row with an empty statement. That is load-bearing: without it the `LEFT JOIN ... WHERE a.pmid IS NULL` query returns that PMID forever and the importer never converges.

## Verification

`--dry-run` is ported from `abstractImport.py`: it processes a random sample of missing PMIDs into a session-private `TEMPORARY` table, reports how many fetched statements contain the poison characters, re-reads the longest one to confirm a verbatim round-trip, then drops the scratch table. `reporting_conflicts` is never touched.

    cd update && python3 conflictsImport.py --dry-run

`update/test_conflicts_import.py` runs offline (no DB, no AWS) and locks down two things: `get_conflicts()` returns `""` and never `None` for every degenerate DynamoDB item shape, and neither importer has reintroduced `LOAD DATA LOCAL INFILE`, `csv.writer`, `local_infile`, or dropped the `p.pmid > 0` guard.

    cd update && python3 test_conflicts_import.py

## Scope limit — read before closing the issue

**This stops new corruption. It does not repair rows the old path already mangled.** The backfill is `LEFT JOIN ... WHERE a.pmid IS NULL`, which only fills *missing* pmids; an existing row holding truncated or concatenated text is never revisited. Repair is a separate PR, and only worth writing if the audit below finds damage.

## Audit result — the table is intact

Run against `reciterdb` (161,155 rows) on 2026-07-28. **No escaping corruption to repair.** Zero duplicate pmids, zero eligible pmids missing a row, zero rows at the blob ceiling, zero field shifts. A verbatim DynamoDB comparison over 1,660 stratified rows found **96.9% exact match and zero escaping damage**. COI statements are short stereotyped prose — 64% under 200 bytes, 1 backslash in 74,170 — so the bug was armed but almost never fired here, unlike on `reporting_abstracts`. Full write-up in #127.

Separately, ~5,100 rows are stored empty while DynamoDB has a statement, because the `LEFT JOIN ... WHERE a.pmid IS NULL` backfill never revisits an existing row. That is staleness, not this bug (poison-character rate among the missing is 3.2% vs 8.6% in the population), and it wants its own issue.

## Tooling

`update/audit_conflicts.sql` — read-only, pure SQL, reads the **blob** (`conflictsVarchar` truncates at 15000 and understates damage):

    mysql -h "$DB_HOST" -u "$DB_USERNAME" -p "$DB_NAME" < update/audit_conflicts.sql

`update/auditConflictsVsDynamo.py` — stored-vs-source comparison plus the blame probe that separates escaping damage from staleness. Fixed RAND seeds so a re-run after a fix is comparable rather than a fresh draw.

`update/audit_conflicts_selftest.sql` — proves the detectors fire, seeding known-good and known-corrupt rows in a scratch database:

    docker run -d --name coi-selftest -e MARIADB_ROOT_PASSWORD=t mariadb:11
    docker cp update/audit_conflicts_selftest.sql coi-selftest:/tmp/
    docker exec coi-selftest mariadb -uroot -pt -e "SOURCE /tmp/audit_conflicts_selftest.sql"

It earned its place three times. Under `utf8mb4_unicode_ci`, `REGEXP '^[a-z]'` also matches uppercase, so `starts_lowercase` reported 7 of 9 healthy rows as corrupt. Then the live run exposed two more false-positive detectors — a boilerplate-repeat check that flagged 5,272 healthy rows, and a punctuation check that flagged 8,646 rows of PubMed's own `<b>` markup. Both are replaced, and the self-test now pins the corrected behaviour. All 10 assertions pass.

## Verification performed

- `python3 -m py_compile` on both changed importers, both branches
- `update/test_conflicts_import.py` — passes; banned-pattern guard confirmed load-bearing against the pre-fix file
- Normalized parity diff vs `abstractImport.py` — only log strings, identifier plurals, the extractor, and the preserved year filter
- `audit_conflicts_selftest.sql` — 10/10 PASS on MariaDB 11
- `audit_conflicts.sql` and `auditConflictsVsDynamo.py` — executed against live `reciterdb`, read-only

**Not verified:** `conflictsImport.py --dry-run` has not been run against production, and the rewritten importer has not yet executed a real nightly.

Ships as a PR pair per #71/#72, #78/#80, #87/#89/#88. The other half carries a byte-identical patch.
