### PR TITLE
feat(aar-scopus): issn column so recheck can journal-filter the existing no-DOI backlog

### DIFF
--- a/setup/alter_authorship_review_add_issn_v2.1.sql
+++ b/setup/alter_authorship_review_add_issn_v2.1.sql
@@ -1,0 +1,53 @@
+-- =============================================================================
+-- Migration: authorship_review add issn (v2.1)
+-- =============================================================================
+-- Adds:
+--   - issn   VARCHAR(9)  NULL  — hyphenated NNNN-NNNC (Scopus gives it unhyphenated;
+--                                the producer normalizes before storing)
+--
+-- WHY THIS MIGRATION EXISTS:
+--   recheck_open_scopus() (update/aar_universe_scopus.py) can only journal-filter a
+--   no-DOI scopus row against PubMed if it has the row's ISSN — but the column never
+--   existed, so the 1,393-row no-DOI backlog (99.5% from the one-time 2026-07-05
+--   --mode initial backfill) could only be skipped by pub_type ('Book'), not by
+--   dead-journal ISSN. This column lets the recheck reach that existing backlog, not
+--   just new rows going forward (ingest-time filtering already has the raw Scopus doc
+--   in hand and doesn't need this column). See
+--   docs/HANDOFF_2026-08-14_authorships_live_session.md thread #4 (ReCiter Research).
+--
+--   The fresh-build schema (setup/table_authorship_review.sql) is updated in the same
+--   PR. This migration brings EXISTING databases up to that schema. It must be applied
+--   directly to BOTH reciterdb instances — the producer instance and the separate dev
+--   instance behind reciter-pm-dev (loaded manually) — same as v1.6. Merging the PR
+--   does NOT run DDL.
+--
+-- DURABILITY: authorship_review is curator state, not a reporting export — not in
+--   update/updateReciterDB.py's truncate list, not touched by any nightly ETL step.
+--
+-- Additive only, guarded by an information_schema check (no-op on re-run). Existing
+-- rows get issn=NULL; the producer backfills it opportunistically as rows are
+-- upserted/rechecked going forward (no bulk backfill of historical rows here — the
+-- title/DOI recheck path already covers them independent of ISSN).
+-- =============================================================================
+
+SET @db = DATABASE();
+
+-- -----------------------------------------------------------------------------
+-- issn VARCHAR(9) NULL — hyphenated NNNN-NNNC
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'issn') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `issn` VARCHAR(9) NULL',
+    'SELECT ''authorship_review.issn already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+SELECT column_name, data_type, character_maximum_length, is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'authorship_review'
+  AND column_name = 'issn';

--- a/setup/table_authorship_review.sql
+++ b/setup/table_authorship_review.sql
@@ -56,6 +56,7 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `entrez_date`            DATE         NULL,                -- ReCiter entrez add date
   `title`                  TEXT         NULL,
   `journal`                VARCHAR(512) NULL,
+  `issn`                   VARCHAR(9)   NULL,                -- hyphenated NNNN-NNNC, scopus only
   `doi`                    VARCHAR(255) NULL,
   `classification`         ENUM('assigned','suggested','buried','absent') NULL,
   `top_cwid`               VARCHAR(32)  NULL,                -- proposed identity

--- a/update/aar_db.py
+++ b/update/aar_db.py
@@ -30,7 +30,7 @@ TABLE = "authorship_review"
 _REFRESH_COLS = [
     "source", "external_id", "pub_type", "container_id",
     "author_position", "author_position_label", "wcm_author", "author_affiliation",
-    "entrez_date", "title", "journal", "doi", "classification",
+    "entrez_date", "title", "journal", "issn", "doi", "classification",
     "top_cwid", "top_name", "top_person_type", "top_dept",
     "top_fg_score", "top_io_score", "top_confidence", "top_cohort_size",
     "top_given_match", "top_affil_match", "n_candidates", "single_candidate",
@@ -69,6 +69,7 @@ CREATE TABLE IF NOT EXISTS {TABLE} (
   entrez_date            DATE         NULL,
   title                  TEXT         NULL,
   journal                VARCHAR(512) NULL,
+  issn                   VARCHAR(9)   NULL,
   doi                    VARCHAR(255) NULL,
   classification         ENUM('assigned','suggested','buried','absent') NULL,
   top_cwid               VARCHAR(32)  NULL,

--- a/update/aar_universe_scopus.py
+++ b/update/aar_universe_scopus.py
@@ -142,10 +142,9 @@ def issn_in_pubmed(issn):
     querytranslation must actually show [Journal] or the "hit" is meaningless.
     Returns None (not False) whenever the ISSN is missing/malformed/unrecognized, so
     callers don't mistake "we can't check" for "confirmed absent"."""
-    issn = (issn or "").strip().upper()
-    if len(issn) != 8:
+    hyphenated = _normalize_issn(issn)
+    if not hyphenated:
         return None
-    hyphenated = f"{issn[:4]}-{issn[4:]}"
     j = _pubmed_esearch(f"{hyphenated}[issn]")
     if not j or "[Journal]" not in (j.get("querytranslation") or ""):
         return None  # not recognized as a journal ISSN — don't trust the count
@@ -174,6 +173,15 @@ def resolve_no_doi(title, author_last, pub_type, issn):
 
 
 # ---- tiny local helpers -----------------------------------------------------
+def _normalize_issn(issn):
+    """Scopus gives ISSN unhyphenated (e.g. '0732183X'); PubMed's [issn] tag and the
+    authorship_review.issn column both want hyphenated NNNN-NNNC. Returns None for
+    anything that isn't exactly 8 chars (missing/malformed — stored as NULL rather
+    than guessed at)."""
+    issn = (issn or "").strip().upper()
+    return f"{issn[:4]}-{issn[4:]}" if len(issn) == 8 else None
+
+
 def _position_label(i, n):
     return "first" if i == 0 else "last" if i == n - 1 else "middle"
 
@@ -324,6 +332,7 @@ def _build_row(entry, i, n, author, top, cands, run_ts):
         "entrez_date": entry.get("prism:coverDate"),   # Scopus has no entrez date; coverDate ~ recency
         "title": entry.get("dc:title"),
         "journal": _trunc(entry.get("prism:publicationName"), 512),
+        "issn": _normalize_issn(entry.get("prism:issn") or entry.get("prism:eIssn")),
         "doi": _trunc(doi, 255),
         "classification": "absent",                    # no PMID -> production never scored it
         "top_cwid": top["cwid"] if top else None,
@@ -345,21 +354,21 @@ def _build_row(entry, i, n, author, top, cands, run_ts):
 # ---- re-check open scopus rows ----------------------------------------------
 def recheck_open_scopus(run_ts):
     """Open scopus rows now PubMed-reachable are resolved out — by DOI when present,
-    else the title fallback, skipping Book entirely (live-measured 8% hit rate — see
-    resolve_no_doi). The PubMed lane will surface them if still orphaned. Guarded on
-    status='open' so a curator's accept/reject is never clobbered. (No dedicated
-    'resolved' ENUM value; dismissed + an auto note is the removal-from-queue state.)
+    else ISSN dead-journal pre-filter + title fallback, skipping Book entirely
+    (live-measured 8% hit rate — see resolve_no_doi). The PubMed lane will surface
+    them if still orphaned. Guarded on status='open' so a curator's accept/reject is
+    never clobbered. (No dedicated 'resolved' ENUM value; dismissed + an auto note is
+    the removal-from-queue state.)
 
-    No ISSN pre-check here unlike resolve_no_doi's ingest-time path — the table has no
-    issn column (never persisted), so an already-stored row can't be journal-filtered
-    without a migration. Deferred; ingest-time filtering already stops new Book/dead-
-    journal rows from accumulating, this only affects rows already in the backlog
-    before that shipped."""
+    `issn` reaches the backlog two ways: rows upserted after the issn column shipped
+    already have it; older rows have issn=NULL until their next producer refresh
+    re-upserts them (source doc still has prism:issn) — until then they just skip
+    straight to the title check, same as before this column existed."""
     from sqlalchemy import text
     eng = aar_db.engine()
     with eng.connect() as c:
         rows = c.execute(text(
-            "SELECT author_key, doi, title, wcm_author, pub_type FROM authorship_review "
+            "SELECT author_key, doi, title, wcm_author, pub_type, issn FROM authorship_review "
             "WHERE source='scopus' AND status='open'")).mappings().all()
     resolved = 0
     for r in rows:
@@ -367,6 +376,8 @@ def recheck_open_scopus(run_ts):
             continue
         if r["doi"]:
             hit = doi_in_pubmed(r["doi"])
+        elif r["issn"] and issn_in_pubmed(r["issn"]) is False:
+            hit = False   # dead journal — a title search would almost certainly miss too
         else:
             author_last = (r["wcm_author"] or "").split()[-1] if r["wcm_author"] else None
             hit = title_in_pubmed(r["title"], author_last)
@@ -541,6 +552,8 @@ def _selftest():
           resolve_no_doi("t", "x", "Book", "12345678") is False)
     check("issn_in_pubmed rejects malformed length without a network call",
           issn_in_pubmed("bad") is None)
+    check("_normalize_issn hyphenates Scopus's unhyphenated form",
+          _normalize_issn("0732183X") == "0732-183X" and _normalize_issn("bad") is None)
     check("rolling window spans [today-90d, today-14d]",
           rolling_window(date(2026, 7, 4)) == ("20260405", "20260620"))
     check("rolling window honours custom lag/span",


### PR DESCRIPTION
Stacked on #136 (title/ISSN PubMed fallback) — needs that merged first.

`resolve_no_doi()`'s ISSN dead-journal pre-filter only runs at ingest time, where the raw Scopus doc (and its `prism:issn`) is in hand. `recheck_open_scopus()` could only skip `Book` for the already-stored 1,393-row no-DOI backlog (99.5% from the one-time 2026-07-05 `--mode initial` backfill) — an already-upserted row had nowhere to keep its ISSN, per thread #4 of `docs/HANDOFF_2026-08-14_authorships_live_session.md` (ReCiter Research repo).

- `setup/alter_authorship_review_add_issn_v2.1.sql` — new idempotent migration (`issn VARCHAR(9) NULL`), same `information_schema`-guarded pattern as v1.6.
- `setup/table_authorship_review.sql` — fresh-build CREATE gets the column too.
- `update/aar_db.py` — `issn` added to the DDL and `_REFRESH_COLS` (upserted/refreshed like `journal`/`doi`, never overwrites curator state).
- `update/aar_universe_scopus.py` — `_build_row()` persists `issn` (via a new `_normalize_issn()` helper shared with `issn_in_pubmed()`); `recheck_open_scopus()` widens its SELECT and skips a row via `issn_in_pubmed()` before falling to the title search when a stored ISSN confirms a dead journal.

**DB status:** applied to **dev** reciterdb already (verified: column present, `varchar(9)`, nullable). **NOT applied to prod** — per the migration's own header (matching the v1.6 convention), merging this PR does not run DDL; needs to be applied by hand to prod before this code reaches it there.

Rows upserted before this shipped have `issn=NULL` until their next producer refresh backfills it — no bulk backfill script; the title/DOI recheck path already covers them independent of ISSN in the meantime.

`--selftest` passes (22 checks, 1 new for `_normalize_issn`'s hyphenation/malformed handling).

Not merging — opening for review per repo convention.