### PR TITLE
fix: gate analysis_summary_article.pmcid on confirmed PMC availability

### DIFF
--- a/setup/createEventsProceduresReciterDb.sql
+++ b/setup/createEventsProceduresReciterDb.sql
@@ -3590,7 +3590,9 @@ proc_main: BEGIN
     )
     SELECT DISTINCT
         pmid,
-        MAX(pmcid),
+        -- #141: gate on datePublicationAddedToPMC so pmcid only reflects confirmed
+        -- full-text availability, not PubMed's raw (often pre-embargo) cross-reference
+        CASE WHEN MAX(datePublicationAddedToPMC) IS NOT NULL THEN MAX(pmcid) END,
         publicationTypeCanonical,
         IF(articleYear != 0, articleYear, LEFT(publicationDateStandardized, 4)),
         MIN(publicationDateStandardized),

--- a/setup/populateAnalysisSummaryTables_v2.sql
+++ b/setup/populateAnalysisSummaryTables_v2.sql
@@ -426,7 +426,9 @@ proc_main: BEGIN
     )
     SELECT DISTINCT
         pmid,
-        MAX(pmcid),
+        -- #141: gate on datePublicationAddedToPMC so pmcid only reflects confirmed
+        -- full-text availability, not PubMed's raw (often pre-embargo) cross-reference
+        CASE WHEN MAX(datePublicationAddedToPMC) IS NOT NULL THEN MAX(pmcid) END,
         publicationTypeCanonical,
         IF(articleYear != 0, articleYear, LEFT(publicationDateStandardized, 4)),
         MIN(publicationDateStandardized),


### PR DESCRIPTION
Closes #141.

`MAX(pmcid)` in `populateAnalysisSummaryTables_v2`'s STEP 3 (both `setup/populateAnalysisSummaryTables_v2.sql` and `setup/createEventsProceduresReciterDb.sql`) copied PubMed's raw `pmcid` cross-reference verbatim, with no check that the article is actually available in PMC — pre-embargo articles get a `pmcid` the moment PubMed links the record, well before full text posts. Downstream: Scholars Profile System's data-sharing dashboard found `Publication.pmcid` non-null for 99.7% of the entire table, implausibly high for a genuine full-text-availability signal (workaround already shipped there: PR #2467/#2473).

`datePublicationAddedToPMC` is already selected in the same query and reflects PubMed's actual `pmc-release` date. Gate `pmcid` on it being set (`CASE WHEN MAX(datePublicationAddedToPMC) IS NOT NULL THEN MAX(pmcid) END`) rather than requiring new upstream parsing work.

Both copies of STEP 3 updated (per repo convention — see CLAUDE.md's note that this procedure is duplicated across the two files, commit b2a8e47 was a fix for exactly this drift).

**Live-verified against prod `person_article`:** of 389,033 rows with `pmcid`, 330,649 have a real `datePublicationAddedToPMC` (kept) and 58,384 don't (nulled). Field is still actively populated for 2026 articles (9,436/9,505), so this isn't gating against a dead signal. `analysis_summary_article` is a full truncate+rebuild each nightly run (RENAME TABLE swap), so no separate backfill needed — this self-heals on the next scheduled run once the procedure is redeployed.

Not applying to dev's DB in this round — dev's `person_article.datePublicationAddedToPMC` is currently 100% empty (separate ingestion gap, tracked in a new issue), so this fix is dev-branch-merged for code parity only for now.