### PR TITLE
fix: gate analysis_summary_article.pmcid on confirmed PMC availability (dev port)

### DIFF
--- a/setup/createEventsProceduresReciterDb.sql
+++ b/setup/createEventsProceduresReciterDb.sql
@@ -3590,7 +3590,9 @@ proc_main: BEGIN
     )
     SELECT DISTINCT
         pmid,
-        MAX(pmcid),
+        -- #141: gate on datePublicationAddedToPMC so pmcid only reflects confirmed
+        -- full-text availability, not PubMed's raw (often pre-embargo) cross-reference
+        CASE WHEN MAX(datePublicationAddedToPMC) IS NOT NULL THEN MAX(pmcid) END,
         publicationTypeCanonical,
         IF(articleYear != 0, articleYear, LEFT(publicationDateStandardized, 4)),
         MIN(publicationDateStandardized),

--- a/setup/populateAnalysisSummaryTables_v2.sql
+++ b/setup/populateAnalysisSummaryTables_v2.sql
@@ -426,7 +426,9 @@ proc_main: BEGIN
     )
     SELECT DISTINCT
         pmid,
-        MAX(pmcid),
+        -- #141: gate on datePublicationAddedToPMC so pmcid only reflects confirmed
+        -- full-text availability, not PubMed's raw (often pre-embargo) cross-reference
+        CASE WHEN MAX(datePublicationAddedToPMC) IS NOT NULL THEN MAX(pmcid) END,
         publicationTypeCanonical,
         IF(articleYear != 0, articleYear, LEFT(publicationDateStandardized, 4)),
         MIN(publicationDateStandardized),


### PR DESCRIPTION
Cherry-picks the master fix for #141 onto `dev` for parity, same as #140 did for #139. See the master PR for full description.

**Not redeploying to dev's live DB in this round.** Live-verified against dev's `person_article`: `datePublicationAddedToPMC` is 100% empty across every entrez-year including 2026's freshly-retrieved articles — not the bug #141 describes, a separate dev-only ingestion gap (prod shows the field actively populated: 9,436/9,505 for 2026). Redeploying this procedure to dev's DB today would null every `pmcid` in dev's `analysis_summary_article` instead of gating the ~15% prod shows. Merging for code parity; will redeploy to dev's DB once the ingestion gap is closed (tracking issue to follow).