### PR TITLE
feat(setup): seed Curator_Scoped role in admin_roles baseline

### DIFF
--- a/setup/insertBaselineDataReciterDb.sql
+++ b/setup/insertBaselineDataReciterDb.sql
@@ -8,7 +8,8 @@ INSERT INTO `admin_roles` (`roleID`, `roleLabel`) VALUES
   (3,'Reporter_All'),
   (4,'Curator_Self'),
   (5,'Curator_Department'),
-  (6,'Curator_Department_Delegate');
+  (6,'Curator_Department_Delegate'),
+  (7,'Curator_Scoped');
 UNLOCK TABLES;
 
 TRUNCATE `analysis_special_characters`;


### PR DESCRIPTION
One-row addition mirroring ReCiter-Publication-Manager's add-curator-scoped-role.sql, which is now applied to both the dev DB (2026-08-14) and the prod DB (2026-08-21, roleID 7). The admin_users scope/proxy JSON columns are already mirrored in createDatabaseTableReciterDb.sql; this completes the PM#849 schema here. Context: wcmc-its/ReCiter-Publication-Manager#849.