### PR TITLE
feat(aar): Scopus authors_json + producer-side dup_flag/dup_reason (v2.2)

### DIFF
--- a/setup/alter_authorship_review_add_dupcheck_and_authors_v2.2.sql
+++ b/setup/alter_authorship_review_add_dupcheck_and_authors_v2.2.sql
@@ -1,0 +1,99 @@
+-- =============================================================================
+-- Migration: authorship_review add authors_json + dup_flag/dup_reason (v2.2)
+-- =============================================================================
+-- Adds:
+--   - authors_json  LONGTEXT     NULL      — Scopus full author list (simplified
+--                                            {given,surname} list); PubMed rows leave
+--                                            this NULL (PubMed already shows the full
+--                                            byline at the PMID link)
+--   - dup_flag      TINYINT(1)   NOT NULL DEFAULT 0  — precomputed "matches an
+--                                            existing external_article by DOI" signal
+--   - dup_reason    VARCHAR(255) NULL      — human-readable note, e.g. "Already added
+--                                            as ExternalArticle for <uid> (DOI match)"
+--
+-- WHY THIS MIGRATION EXISTS:
+--   Round 2 of the PM feedback pass (docs/PLAN_2026-08-24_pm-feedback-round2.md,
+--   "Round 2 — cross-cutting, needs a human at the DB" in the ReCiter Research
+--   project) bundles two producer-side gaps into one migration to minimize how many
+--   times anyone touches prod DDL:
+--
+--   authors_json — aar_universe_scopus.py's wcm_authorships() already parses the FULL
+--   per-document author array from the Scopus Search API COMPLETE-view response, but
+--   _build_row() only ever stored the one WCM-matched author, discarding every other
+--   author. Curators reviewing a Scopus-sourced row had no way to see the paper's full
+--   byline (unlike PubMed rows, which link straight to the PMID where PubMed shows it).
+--   This is "stop discarding," not "start fetching" — no new Scopus API calls.
+--
+--   dup_flag/dup_reason — a curator could spend time on Accept/Assign for a row whose
+--   underlying paper was ALREADY manually added to that person's record as an
+--   ExternalArticle (PM's "Add publication"), with the only present-day check being a
+--   live 409 at click time. reciterdb already runs update/retrieveExternalArticles.py
+--   nightly, projecting DynamoDB's ExternalArticle table into MySQL `external_article`
+--   BEFORE the weekly AAR lane runs — so a plain SQL join against external_article.doi
+--   precomputes "already added" for the large majority of cases at producer time. The
+--   live 409 check at Accept/Assign time (Publication Manager, out of scope here) stays
+--   as a final write-time safety net for same-day races between weekly producer runs;
+--   this column is a heads-up, not a replacement.
+--
+--   The fresh-build schema (setup/table_authorship_review.sql) is updated in the same
+--   PR. This migration brings EXISTING databases up to that schema. It must be applied
+--   directly to BOTH reciterdb instances — the producer instance and the separate dev
+--   instance behind reciter-pm-dev (loaded manually) — same as v1.6 and v2.1. Merging
+--   the PR does NOT run DDL.
+--
+-- DURABILITY: authorship_review is curator state, not a reporting export — not in
+--   update/updateReciterDB.py's truncate list, not touched by any nightly ETL step.
+--
+-- Additive only, guarded by an information_schema check per column (no-op on re-run).
+-- Existing rows get authors_json=NULL, dup_flag=0, dup_reason=NULL; the producer
+-- backfills authors_json/dup_flag/dup_reason opportunistically as rows are upserted/
+-- rechecked going forward (no bulk backfill of historical rows here — the Scopus
+-- --mode initial backfill, when re-run per the plan doc's sequencing, covers the
+-- historical authors_json backlog; dup_flag/dup_reason likewise refresh on the next
+-- producer run for any given row).
+-- =============================================================================
+
+SET @db = DATABASE();
+
+-- -----------------------------------------------------------------------------
+-- authors_json LONGTEXT NULL — Scopus full author list, scopus rows only
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'authors_json') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `authors_json` LONGTEXT NULL',
+    'SELECT ''authorship_review.authors_json already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- dup_flag TINYINT(1) NOT NULL DEFAULT 0 — precomputed ExternalArticle DOI match
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'dup_flag') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `dup_flag` TINYINT(1) NOT NULL DEFAULT 0',
+    'SELECT ''authorship_review.dup_flag already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- dup_reason VARCHAR(255) NULL — human-readable note for dup_flag=1
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'dup_reason') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `dup_reason` VARCHAR(255) NULL',
+    'SELECT ''authorship_review.dup_reason already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+SELECT column_name, data_type, character_maximum_length, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'authorship_review'
+  AND column_name IN ('authors_json', 'dup_flag', 'dup_reason')
+ORDER BY column_name;

--- a/setup/table_authorship_review.sql
+++ b/setup/table_authorship_review.sql
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `journal`                VARCHAR(512) NULL,
   `issn`                   VARCHAR(9)   NULL,                -- hyphenated NNNN-NNNC, scopus only
   `doi`                    VARCHAR(255) NULL,
+  `authors_json`           LONGTEXT     NULL,                -- Scopus full author list, scopus only
   `classification`         ENUM('assigned','suggested','buried','absent') NULL,
   `top_cwid`               VARCHAR(32)  NULL,                -- proposed identity
   `top_name`               VARCHAR(255) NULL,
@@ -72,6 +73,8 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `n_candidates`           INT          NULL,
   `single_candidate`       TINYINT(1)   NULL,                -- cohort_size == 1
   `candidate_cwids_json`   LONGTEXT     NULL,                -- ranked alternates
+  `dup_flag`               TINYINT(1)   NOT NULL DEFAULT 0,  -- matches an external_article by DOI
+  `dup_reason`             VARCHAR(255) NULL,                -- e.g. "Already added as ExternalArticle for <uid> (DOI match)"
   `status`                 ENUM('open','assigned','accepted','rejected','dismissed','snoozed')
                                         NOT NULL DEFAULT 'open',   -- curator state
   `resolution_cwid`        VARCHAR(32)  NULL,

--- a/update/aar_db.py
+++ b/update/aar_db.py
@@ -22,7 +22,7 @@ Usage:
 """
 import argparse, json, os
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import bindparam, create_engine, text
 
 TABLE = "authorship_review"
 
@@ -30,11 +30,11 @@ TABLE = "authorship_review"
 _REFRESH_COLS = [
     "source", "external_id", "pub_type", "container_id",
     "author_position", "author_position_label", "wcm_author", "author_affiliation",
-    "entrez_date", "title", "journal", "issn", "doi", "classification",
+    "entrez_date", "title", "journal", "issn", "doi", "authors_json", "classification",
     "top_cwid", "top_name", "top_person_type", "top_dept",
     "top_fg_score", "top_io_score", "top_confidence", "top_cohort_size",
     "top_given_match", "top_affil_match", "n_candidates", "single_candidate",
-    "candidate_cwids_json", "last_refreshed",
+    "candidate_cwids_json", "dup_flag", "dup_reason", "last_refreshed",
 ]
 # full insert column set (curator columns default on first insert)
 _INSERT_COLS = ["pmid", "author_key"] + _REFRESH_COLS + [
@@ -71,6 +71,7 @@ CREATE TABLE IF NOT EXISTS {TABLE} (
   journal                VARCHAR(512) NULL,
   issn                   VARCHAR(9)   NULL,
   doi                    VARCHAR(255) NULL,
+  authors_json           LONGTEXT     NULL,
   classification         ENUM('assigned','suggested','buried','absent') NULL,
   top_cwid               VARCHAR(32)  NULL,
   top_name               VARCHAR(255) NULL,
@@ -85,6 +86,8 @@ CREATE TABLE IF NOT EXISTS {TABLE} (
   n_candidates           INT          NULL,
   single_candidate       TINYINT(1)   NULL,
   candidate_cwids_json   LONGTEXT     NULL,
+  dup_flag               TINYINT(1)   NOT NULL DEFAULT 0,
+  dup_reason             VARCHAR(255) NULL,
   status                 ENUM('open','assigned','accepted','rejected','dismissed','snoozed')
                                       NOT NULL DEFAULT 'open',
   resolution_cwid        VARCHAR(32)  NULL,
@@ -132,6 +135,35 @@ def upsert(rows):
             c.execute(stmt, [{k: r.get(k) for k in _INSERT_COLS} for r in chunk])
             n += len(chunk)
     return n
+
+
+def dup_flags_by_doi(dois):
+    """doi -> (uid, article_id) for DOIs already present in reciterdb `external_article`
+    (the nightly ExternalArticle projection, update/retrieveExternalArticles.py, which
+    runs before the weekly AAR lane). Lives here (not aar_orchestrator.py) so both the
+    PubMed lane (aar_orchestrator._db_rows) and the self-contained Scopus lane
+    (aar_universe_scopus, which deliberately avoids importing the xgboost/S3-heavy
+    PubMed-lane modules) can call it without a heavier import.
+
+    Used to precompute authorship_review.dup_flag/dup_reason at producer time, so a
+    curator sees an "already added" heads-up before spending a click on Accept/Assign.
+    The live 409 conflict check at Accept/Assign time (Publication Manager) stays as
+    the final same-day-race safety net — this is a heads-up, not a replacement.
+
+    Batched (500 DOIs/query) rather than one unbounded IN-clause, same convention as
+    aar_gate.attributed_pmids / this module's own upsert() chunking. Read-only."""
+    dois = sorted({d for d in dois if d})
+    out = {}
+    if not dois:
+        return out
+    stmt = text("SELECT doi, uid, article_id FROM external_article WHERE doi IN :ds") \
+        .bindparams(bindparam("ds", expanding=True))
+    with engine().connect() as c:
+        for i in range(0, len(dois), 500):
+            chunk = dois[i:i + 500]
+            for doi, uid, article_id in c.execute(stmt, {"ds": chunk}):
+                out.setdefault(doi, (uid, article_id))
+    return out
 
 
 def _describe():

--- a/update/aar_db.py
+++ b/update/aar_db.py
@@ -151,7 +151,12 @@ def dup_flags_by_doi(dois):
     the final same-day-race safety net — this is a heads-up, not a replacement.
 
     Batched (500 DOIs/query) rather than one unbounded IN-clause, same convention as
-    aar_gate.attributed_pmids / this module's own upsert() chunking. Read-only."""
+    aar_gate.attributed_pmids / this module's own upsert() chunking. Read-only.
+
+    Keyed by lowercased DOI: MySQL's IN-clause match is case-insensitive (ci collation),
+    but a plain Python dict lookup isn't -- without normalizing both sides, a DOI that
+    differs only in case between authorship_review and external_article would join fine
+    in SQL yet silently miss the dict lookup, under-flagging the duplicate."""
     dois = sorted({d for d in dois if d})
     out = {}
     if not dois:
@@ -162,7 +167,7 @@ def dup_flags_by_doi(dois):
         for i in range(0, len(dois), 500):
             chunk = dois[i:i + 500]
             for doi, uid, article_id in c.execute(stmt, {"ds": chunk}):
-                out.setdefault(doi, (uid, article_id))
+                out.setdefault(doi.lower(), (uid, article_id))
     return out
 
 

--- a/update/aar_orchestrator.py
+++ b/update/aar_orchestrator.py
@@ -155,7 +155,12 @@ def _db_rows(resolved_auth, run_date):
     absent (top candidate never scored) / suggested (FG>=30, in a pending queue) /
     buried (FG<30). Includes suggested rows (PM shows them with FG+IO). Unmatched
     authorships (no candidate to assign) are skipped in v1. single_candidate uses the
-    true cohort size (unique surname+initial), the strongest precision signal."""
+    true cohort size (unique surname+initial), the strongest precision signal.
+
+    dup_flag/dup_reason: one batched aar_db.dup_flags_by_doi() call over every DOI in
+    this run's resolved_auth (not a query per row) — see that function's docstring."""
+    dois = {a.get("doi") for a, i, n, au, cands, top in resolved_auth if a.get("doi")}
+    dup_map = aar_db.dup_flags_by_doi(dois) if dois else {}
     out = []
     for a, i, n, au, cands, top in resolved_auth:
         if top is None:
@@ -164,6 +169,8 @@ def _db_rows(resolved_auth, run_date):
         cls = ("absent" if fg is None
                else "suggested" if fg >= gate.STORAGE_THRESHOLD else "buried")
         cohort = top.get("cohort_size")
+        doi = a.get("doi")
+        dup_hit = dup_map.get(doi) if doi else None
         out.append({
             "source": "pubmed",
             "pmid": a["pmid"],
@@ -185,6 +192,9 @@ def _db_rows(resolved_auth, run_date):
             "top_affil_match": int(bool(top["affil_dept_match"])),
             "n_candidates": len(cands), "single_candidate": int(cohort == 1),
             "candidate_cwids_json": json.dumps(_compact(cands)),
+            "dup_flag": int(bool(dup_hit)),
+            "dup_reason": (f"Already added as ExternalArticle for {dup_hit[0]} (DOI match)"
+                           if dup_hit else None),
             "status": "open", "first_seen": run_date,
             "last_checked": run_date, "last_refreshed": run_date,
         })

--- a/update/aar_orchestrator.py
+++ b/update/aar_orchestrator.py
@@ -170,7 +170,7 @@ def _db_rows(resolved_auth, run_date):
                else "suggested" if fg >= gate.STORAGE_THRESHOLD else "buried")
         cohort = top.get("cohort_size")
         doi = a.get("doi")
-        dup_hit = dup_map.get(doi) if doi else None
+        dup_hit = dup_map.get(doi.lower()) if doi else None
         out.append({
             "source": "pubmed",
             "pmid": a["pmid"],

--- a/update/aar_universe_scopus.py
+++ b/update/aar_universe_scopus.py
@@ -380,7 +380,7 @@ def _build_row(entry, i, n, author, top, cands, run_ts, dup_map=None):
     # by DOI against reciterdb.external_article (aar_db.dup_flags_by_doi, batched once
     # per run() call, not per row — see that function's docstring). Live 409 at
     # Accept/Assign time (Publication Manager) remains the final same-day-race check.
-    dup_hit = (dup_map or {}).get(doi) if doi else None
+    dup_hit = (dup_map or {}).get(doi.lower()) if doi else None
     return {
         "source": "scopus", "pmid": None,
         # numeric Scopus record id -> the PM Accept builds articleId "SCOPUS:<external_id>"

--- a/update/aar_universe_scopus.py
+++ b/update/aar_universe_scopus.py
@@ -356,12 +356,31 @@ def wcm_authorships(entry, family):
         }, hits
 
 
-def _build_row(entry, i, n, author, top, cands, run_ts):
+def _authors_json(entry):
+    """Simplified {given,surname} list of EVERY author on the document (not just the
+    WCM-matched one) — the Scopus Search API COMPLETE view already returns this full
+    array (entry.get("author")); _build_row() previously discarded everyone but the
+    one WCM author, leaving curators no way to see the paper's byline the way a PubMed
+    row's PMID link shows it. Scopus-internal fields (@seq/afid) are dropped — this is
+    a curator-facing display list, not a re-parseable structure. Always a JSON array
+    string, never null, even when the document has no author field."""
+    return json.dumps([
+        {"given": a.get("given-name"), "surname": a.get("surname")}
+        for a in _as_list(entry.get("author"))
+    ])
+
+
+def _build_row(entry, i, n, author, top, cands, run_ts, dup_map=None):
     doi = entry.get("prism:doi")
     sid = _numeric_scopus_id(entry.get("eid"))
     dedup = doi or sid          # author_key identity: DOI-first, stable across Scopus record merges
     pub_type = entry.get("subtypeDescription")
     cohort = top.get("cohort_size") if top else None
+    # dup_flag/dup_reason: heads-up "already added as ExternalArticle" signal, joined
+    # by DOI against reciterdb.external_article (aar_db.dup_flags_by_doi, batched once
+    # per run() call, not per row — see that function's docstring). Live 409 at
+    # Accept/Assign time (Publication Manager) remains the final same-day-race check.
+    dup_hit = (dup_map or {}).get(doi) if doi else None
     return {
         "source": "scopus", "pmid": None,
         # numeric Scopus record id -> the PM Accept builds articleId "SCOPUS:<external_id>"
@@ -379,6 +398,7 @@ def _build_row(entry, i, n, author, top, cands, run_ts):
         "journal": _trunc(entry.get("prism:publicationName"), 512),
         "issn": _normalize_issn(entry.get("prism:issn") or entry.get("prism:eIssn")),
         "doi": _trunc(doi, 255),
+        "authors_json": _authors_json(entry),
         "classification": "absent",                    # no PMID -> production never scored it
         "top_cwid": top["cwid"] if top else None,
         "top_name": _trunc(top["name"], 255) if top else None,
@@ -391,6 +411,9 @@ def _build_row(entry, i, n, author, top, cands, run_ts):
         "top_affil_match": int(bool(top["affil_dept_match"])) if top else None,
         "n_candidates": len(cands), "single_candidate": int(cohort == 1) if cohort else None,
         "candidate_cwids_json": json.dumps(_compact(cands)),
+        "dup_flag": int(bool(dup_hit)),
+        "dup_reason": (f"Already added as ExternalArticle for {dup_hit[0]} (DOI match)"
+                       if dup_hit else None),
         "status": "open", "first_seen": run_ts,
         "last_checked": run_ts, "last_refreshed": run_ts,
     }
@@ -479,6 +502,11 @@ def run(aft, bef, apply_writes=False, afid_list=DEFAULT_AFID_LIST, recheck=True,
     print("[4/5] Matching WCM authorships against the identity roster ...", flush=True)
     if idx is None:
         idx = IdentityIndex.load()
+    # one batched dup-check join over every DOI in this month/window, not a query per
+    # row (aar_db.dup_flags_by_doi docstring) — mirrors the "load the roster once"
+    # convention already used for idx above.
+    dois = {d.get("prism:doi") for d in scopus_only if d.get("prism:doi")}
+    dup_map = aar_db.dup_flags_by_doi(dois) if dois else {}
     rows, unmatched = [], 0
     for d in scopus_only:
         for i, n, au, _ in wcm_authorships(d, family):
@@ -488,7 +516,7 @@ def run(aft, bef, apply_writes=False, afid_list=DEFAULT_AFID_LIST, recheck=True,
             if top is None:
                 unmatched += 1                         # nothing to assign (v1 skips unmatched)
                 continue
-            rows.append(_build_row(d, i, n, au, top, cands, run_ts))
+            rows.append(_build_row(d, i, n, au, top, cands, run_ts, dup_map=dup_map))
     print(f"      {len(rows)} matched authorships; {unmatched} unmatched (skipped)", flush=True)
 
     if apply_writes:
@@ -652,6 +680,20 @@ def _selftest():
           row["classification"] == "absent"
           and row["top_fg_score"] is None and row["top_io_score"] is None)
     check("row single_candidate=1", row["single_candidate"] == 1)
+    check("row authors_json lists both authors on the document, not just the WCM one",
+          json.loads(row["authors_json"]) == [
+              {"given": "Jane", "surname": "Smith"}, {"given": "John", "surname": "Doe"}])
+    check("row dup_flag=0/dup_reason=None with no dup_map (default)",
+          row["dup_flag"] == 0 and row["dup_reason"] is None)
+
+    row_dup = _build_row(entry, i, n, au, top, [top], "2026-07-03 00:00:00",
+                         dup_map={"10.1/x": ("abc1234", "SCOPUS:105037523511")})
+    check("row dup_flag=1 and dup_reason names the uid when the DOI is in dup_map",
+          row_dup["dup_flag"] == 1 and row_dup["dup_reason"]
+          == "Already added as ExternalArticle for abc1234 (DOI match)")
+
+    check("_authors_json returns '[]' (not null) when the document has no author field",
+          _authors_json({}) == "[]")
 
     entry2 = dict(entry, **{"prism:doi": None})
     au2 = {"last": "Smith", "fore": "Jane", "initials": "J.", "affiliations": []}


### PR DESCRIPTION
Round 2 of the PM feedback pass (`docs/PLAN_2026-08-24_pm-feedback-round2.md`, ReCiter Research project). **ReCiterDB half only** — the Publication Manager (TypeScript) half is a separate, later PR, sequenced after PR #907 lands (same two PM files, to avoid a third conflicting PR).

**Part A — `authors_json` (Scopus full-author-list gap):** `aar_universe_scopus.py`'s `wcm_authorships()` already parses the full per-document Scopus author array, but `_build_row()` only ever stored the one WCM-matched author, discarding everyone else — a curator reviewing a Scopus-sourced row had no way to see the paper's full byline (unlike PubMed rows, which link straight to the PMID). `_build_row()` now also stores `authors_json`, a simplified `{given,surname}` list of every author on the document. No new API calls — this is stop-discarding, not start-fetching. PubMed-lane `_db_rows()` is untouched; `authors_json` stays NULL there (PubMed already shows the byline at the PMID link).

**Part B — `dup_flag`/`dup_reason` (already-added-as-ExternalArticle heads-up):** a curator could spend a click on Accept/Assign for a row whose paper was already manually added to that person's record as an `ExternalArticle`, with only a live 409 at click time to catch it. `retrieveExternalArticles.py` already runs nightly, projecting DynamoDB's `ExternalArticle` table into MySQL's `external_article` table before the weekly AAR lane — so a batched SQL join by DOI (`aar_db.dup_flags_by_doi`, new, 500 DOIs/query) precomputes the common case at producer time. Wired into both lanes (`aar_orchestrator._db_rows` for PubMed, `aar_universe_scopus._build_row` for Scopus), one join per producer run over the full DOI set, not one query per row. The live 409 check in Publication Manager (untouched, out of scope here) stays as the final same-day-race safety net.

**Files:**
- `setup/alter_authorship_review_add_dupcheck_and_authors_v2.2.sql` (new) — idempotent migration (`authors_json` LONGTEXT NULL, `dup_flag` TINYINT(1) NOT NULL DEFAULT 0, `dup_reason` VARCHAR(255) NULL), same information_schema-guarded PREPARE/EXECUTE/DEALLOCATE pattern as the existing `_v2.1` migration. **Not applied to any database from this PR** — needs to be run by hand against both reciterdb instances per this repo's established convention (see the migration's own header).
- `setup/table_authorship_review.sql` — fresh-build schema gets all three columns.
- `update/aar_db.py` — `_REFRESH_COLS`/DDL extended; new `dup_flags_by_doi()` helper.
- `update/aar_orchestrator.py` — `_db_rows()` computes `dup_flag`/`dup_reason` via one batched call.
- `update/aar_universe_scopus.py` — `_build_row()` persists `authors_json` + `dup_flag`/`dup_reason`.

**Verification:** `python3 -c "import ast; ast.parse(...)"` clean on all three touched `.py` files. `aar_universe_scopus.py --selftest`: 28/28 checks pass, fully offline (no DB/API credentials needed). Migration SQL not run against any live database from this sandbox.

Fable review caught a real correctness gap in the first pass — `dup_flags_by_doi`'s dict was keyed by the DB-returned DOI casing while lookups used each row's own DOI casing; MySQL's `IN`-clause match is case-insensitive but the Python dict lookup wasn't, so a case-mismatched DOI would silently join in SQL but miss the dict lookup (`dup_flag` staying 0 for a real duplicate). Fixed by lowercasing both the dict keys and both lookup sites — re-verified (selftest still 28/28, plus an independent mixed-case probe confirming the fix).

**Sequencing per the plan doc:** this PR + a follow-up PM PR are opened for review; once approved, the migration SQL needs to be hand-run against both reciterdb instances before these PRs merge to their prod lines; then a backfill re-run (`--mode initial`) populates `authors_json` for the historical backlog.
