### PR TITLE
Atomic table swap for the nightly load, removing the daily reporting-DB outage window

### DIFF
--- a/update/retrieveArticles.py
+++ b/update/retrieveArticles.py
@@ -540,6 +540,15 @@ def main():
     updateReciterDB.call_update_person_only()
     logger.info("Final UPDATE_PERSON completed.")
 
+    # Step 7: Atomic table swap -- promote the `_new` shadow tables (built
+    # throughout this run) into the live table names with a single RENAME.
+    # Must run after Step 6 above so the person table being swapped in
+    # already has firstName/lastName/etc. populated. No-op unless the
+    # nightly loader is running with ATOMIC_SWAP=1.
+    logger.info("Calling swap_new_tables_into_place (no-op unless ATOMIC_SWAP=1).")
+    updateReciterDB.swap_new_tables_into_place()
+    logger.info("Table swap step complete.")
+
     # Log final debugging info about processed/skipped UIDs
     logger.info(f"Processed UIDs count: {len(processed_uids)}")
     logger.info(f"Skipped UIDs count: {len(skipped_uids)}")

--- a/update/test_atomic_swap.py
+++ b/update/test_atomic_swap.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Pure-logic regression tests for the atomic table-swap nightly loader.
+
+No database connection is made or required -- these exercise only the two
+functions that decide *which* table name a statement targets and *what* the
+final RENAME TABLE statement looks like:
+
+1. shadow_table_name() -- routes LOAD DATA / UPDATE targets to `<table>_new`
+   when ATOMIC_SWAP is on and the table participates in the swap, and leaves
+   everything else (including person_temp) untouched.
+2. build_swap_rename_sql() -- constructs the single atomic RENAME TABLE
+   statement that promotes every `_new` shadow table into its live name.
+
+Run: python3 test_atomic_swap.py
+"""
+import updateReciterDB as u
+
+
+def test_shadow_table_name_off_by_default():
+    # ATOMIC_SWAP defaults to False (no ATOMIC_SWAP=1 in this process's env).
+    assert u.ATOMIC_SWAP is False
+    for t in u.SWAP_TABLES:
+        assert u.shadow_table_name(t) == t, f"expected no routing for {t} when ATOMIC_SWAP is off"
+    assert u.shadow_table_name('person_temp') == 'person_temp'
+
+
+def test_shadow_table_name_routes_swap_tables_when_on():
+    original = u.ATOMIC_SWAP
+    try:
+        u.ATOMIC_SWAP = True
+        for t in u.SWAP_TABLES:
+            assert u.shadow_table_name(t) == f"{t}_new", f"{t} did not route to its shadow table"
+    finally:
+        u.ATOMIC_SWAP = original
+
+
+def test_shadow_table_name_never_routes_person_temp():
+    # person_temp is internal staging, explicitly excluded from the swap set,
+    # and must never be routed to person_temp_new even when swap mode is on.
+    original = u.ATOMIC_SWAP
+    try:
+        u.ATOMIC_SWAP = True
+        assert 'person_temp' not in u.SWAP_TABLES
+        assert u.shadow_table_name('person_temp') == 'person_temp'
+    finally:
+        u.ATOMIC_SWAP = original
+
+
+def test_shadow_table_name_ignores_unknown_tables_when_on():
+    # A table outside the swap set (e.g. analysis_summary_* tables owned by a
+    # different job) must pass through unchanged even in swap mode.
+    original = u.ATOMIC_SWAP
+    try:
+        u.ATOMIC_SWAP = True
+        assert u.shadow_table_name('analysis_summary_person') == 'analysis_summary_person'
+    finally:
+        u.ATOMIC_SWAP = original
+
+
+def test_swap_tables_excludes_person_temp():
+    assert 'person_temp' not in u.SWAP_TABLES
+    # And covers exactly the 10 real data tables named in updateReciterDB's
+    # own all_tables list (person_temp aside).
+    assert len(u.SWAP_TABLES) == 10
+    assert len(set(u.SWAP_TABLES)) == 10, "SWAP_TABLES must not contain duplicates"
+
+
+def test_build_swap_rename_sql_is_single_statement():
+    sql = u.build_swap_rename_sql()
+    assert sql.startswith("RENAME TABLE ")
+    assert sql.endswith(";")
+    # Exactly one statement -- no stray semicolons that would split this into
+    # multiple non-atomic RENAMEs.
+    assert sql.count(';') == 1
+
+
+def test_build_swap_rename_sql_covers_every_swap_table_both_directions():
+    sql = u.build_swap_rename_sql()
+    for t in u.SWAP_TABLES:
+        assert f"`{t}` TO `{t}_old`" in sql, f"{t} -> {t}_old clause missing"
+        assert f"`{t}_new` TO `{t}`" in sql, f"{t}_new -> {t} clause missing"
+    # And nothing else snuck in.
+    assert "person_temp" not in sql
+
+
+def test_build_swap_rename_sql_matches_ticket_form():
+    # Verbatim shape requested: RENAME TABLE person TO person_old,
+    # person_new TO person, person_article TO person_article_old, ... ;
+    sql = u.build_swap_rename_sql()
+    person_idx = sql.index("`person` TO `person_old`")
+    person_new_idx = sql.index("`person_new` TO `person`")
+    person_article_idx = sql.index("`person_article` TO `person_article_old`")
+    assert person_idx < person_new_idx < person_article_idx, (
+        "clause order must be: person->person_old, person_new->person, "
+        "person_article->person_article_old, ..."
+    )
+
+
+if __name__ == "__main__":
+    test_shadow_table_name_off_by_default()
+    test_shadow_table_name_routes_swap_tables_when_on()
+    test_shadow_table_name_never_routes_person_temp()
+    test_shadow_table_name_ignores_unknown_tables_when_on()
+    test_swap_tables_excludes_person_temp()
+    test_build_swap_rename_sql_is_single_statement()
+    test_build_swap_rename_sql_covers_every_swap_table_both_directions()
+    test_build_swap_rename_sql_matches_ticket_form()
+    print("OK: shadow-table routing and RENAME TABLE construction verified (no DB).")

--- a/update/updateReciterDB.py
+++ b/update/updateReciterDB.py
@@ -56,6 +56,21 @@ SWAP_TABLES = [
     'person_person_type',
 ]
 
+# RENAME TABLE safety / disk-space analysis (verified against this repo):
+# - FOREIGN KEYs: none of the 10 SWAP_TABLES is referenced by a FOREIGN KEY
+#   anywhere in setup/createDatabaseTableReciterDb.sql -- the only FKs in that
+#   file are on the admin_* auth tables, which are untouched by this swap.
+# - TRIGGERs / VIEWs: setup/ contains no SQL TRIGGERs and no SQL VIEWs. The
+#   only "view" hit is a stored procedure named `view_job_progress`, not a
+#   database VIEW.
+# - Stored procedures: table names inside them resolve at execution time, so
+#   a RENAME TABLE between runs is safe -- no procedure can be left pointing
+#   at a stale/renamed table.
+# - Disk space: every swap table exists twice (live + `_new`) for the full
+#   build window, so peak usage is roughly 2x the combined footprint of the
+#   10 SWAP_TABLES. person_article_author (~3.9M rows) dominates that total.
+#   Confirm headroom on the target volume before enabling ATOMIC_SWAP=1 in
+#   production.
 
 def shadow_table_name(table_name):
     """Return the table this run should actually load/update: `<table_name>_new`
@@ -294,12 +309,15 @@ def main(truncate_tables=True, skip_person_temp=False):
             for table in all_tables:
                 if ATOMIC_SWAP and table in SWAP_TABLES:
                     # Build into a shadow table instead of truncating the live one.
-                    # CREATE ... LIKE copies structure/indexes (no data); TRUNCATE
-                    # clears out any partial data left by a prior crashed run.
-                    create_sql = f"CREATE TABLE IF NOT EXISTS `{table}_new` LIKE `{table}`;"
+                    # Drop any `_new` left by a prior crashed run before recreating it
+                    # -- CREATE ... IF NOT EXISTS would silently reuse that leftover
+                    # table, which may carry a stale schema if a migration has since
+                    # altered the live table. Drop-then-CREATE ... LIKE guarantees the
+                    # shadow table always matches the live schema exactly.
+                    drop_sql = f"DROP TABLE IF EXISTS `{table}_new`;"
+                    cursor = execute_with_reconnect(cursor, drop_sql)
+                    create_sql = f"CREATE TABLE `{table}_new` LIKE `{table}`;"
                     cursor = execute_with_reconnect(cursor, create_sql)
-                    truncate_sql = f"TRUNCATE TABLE `{table}_new`;"
-                    cursor = execute_with_reconnect(cursor, truncate_sql)
                 else:
                     sql = f"TRUNCATE TABLE `{table}`;"
                     cursor = execute_with_reconnect(cursor, sql)
@@ -457,6 +475,18 @@ def main(truncate_tables=True, skip_person_temp=False):
             cursor = update_person(cursor)
 
         connection.commit()
+
+        if ATOMIC_SWAP:
+            logger.warning(
+                "ATOMIC_SWAP=1: this run wrote to `<table>_new` SHADOW TABLES, not the "
+                "live tables. That data will NOT be visible to readers until "
+                "swap_new_tables_into_place() runs. The nightly path (retrieveArticles.py) "
+                "calls that automatically after the identity merge -- but if this main() "
+                "call came from a manual/recovery run of retrieveS3.py or "
+                "retrieveDynamoDb.py, nothing promotes the shadow tables for you. Run "
+                "updateReciterDB.swap_new_tables_into_place() yourself, or the live "
+                "tables will silently keep serving the prior run's data."
+            )
 
     except Exception as e:
         logger.error(f"An error occurred: {e}")

--- a/update/updateReciterDB.py
+++ b/update/updateReciterDB.py
@@ -27,6 +27,56 @@ CONNECT_TIMEOUT = 10   # seconds
 connection = None
 
 # ------------------------------------------------------------------------------
+#                     ATOMIC TABLE SWAP CONFIG
+# ------------------------------------------------------------------------------
+# When ATOMIC_SWAP=1, the nightly load builds into `<table>_new` shadow tables
+# instead of truncating the live tables and rebuilding them in place, then
+# promotes the shadow tables into their live names with a single atomic
+# RENAME TABLE at the very end (swap_new_tables_into_place(), called from
+# retrieveArticles.py after the final identity merge). This removes the daily
+# window where the live tables are empty/partial while being read for
+# reporting. Mirrors the pattern in setup/populateAnalysisSummaryTables_v2.sql
+# ("7. Atomic table swap"), adapted to Python/pymysql and to `_old`/immediate
+# drop instead of that script's `_backup`/next-run drop.
+#
+# Default OFF: this is the core nightly loader and this branch has not been
+# exercised against a real database. Opt in explicitly with ATOMIC_SWAP=1
+# (env var on the reciterdb CronJob) once verified on dev.
+ATOMIC_SWAP = os.getenv("ATOMIC_SWAP", "0") == "1"
+
+# The 10 tables that participate in the atomic swap. person_temp is
+# deliberately excluded -- it is internal staging, always truncated and
+# loaded in place, never swapped.
+SWAP_TABLES = [
+    'person', 'person_article', 'person_article_author',
+    'person_article_department', 'person_article_grant',
+    'person_article_keyword', 'person_article_relationship',
+    'person_article_scopus_target_author_affiliation',
+    'person_article_scopus_non_target_author_affiliation',
+    'person_person_type',
+]
+
+
+def shadow_table_name(table_name):
+    """Return the table this run should actually load/update: `<table_name>_new`
+    when atomic-swap mode is on and the table participates in the swap,
+    otherwise `table_name` unchanged. Pure string logic, no DB access."""
+    if ATOMIC_SWAP and table_name in SWAP_TABLES:
+        return f"{table_name}_new"
+    return table_name
+
+
+def build_swap_rename_sql():
+    """Build the single atomic RENAME TABLE statement that promotes every
+    `_new` shadow table into its live name, moving the current live table to
+    `_old` in the same statement. Pure string construction, no DB access."""
+    clauses = []
+    for t in SWAP_TABLES:
+        clauses.append(f"`{t}` TO `{t}_old`")
+        clauses.append(f"`{t}_new` TO `{t}`")
+    return "RENAME TABLE " + ", ".join(clauses) + ";"
+
+# ------------------------------------------------------------------------------
 #                     EXECUTE WITH RECONNECT
 # ------------------------------------------------------------------------------
 def execute_with_reconnect(cursor, sql):
@@ -158,9 +208,10 @@ def load_person_temp(cursor, csv_file_path):
 
 def update_person(cursor):
     current_time = time.strftime("%Y-%m-%d %H:%M:%S")
-    logger.info(f"{current_time} -- Starting update_person.")
-    update_query = """
-    UPDATE person p
+    target_table = shadow_table_name('person')
+    logger.info(f"{current_time} -- Starting update_person (target: `{target_table}`).")
+    update_query = f"""
+    UPDATE `{target_table}` p
     JOIN person_temp i ON i.personIdentifier = p.personIdentifier
     SET p.firstName = i.firstName,
         p.middleName = i.middleName,
@@ -172,7 +223,7 @@ def update_person(cursor):
         p.relationshipIdentityCount = i.relationshipIdentityCount;
     """
     cursor = execute_with_reconnect(cursor, update_query)
-    logger.info(f"{current_time} -- person table updated with data from person_temp table.")
+    logger.info(f"{current_time} -- `{target_table}` table updated with data from person_temp table.")
     return cursor
 
 def load_table_once(cursor, csv_file_path, table_name, columns, already_loaded_tables):
@@ -184,14 +235,15 @@ def load_table_once(cursor, csv_file_path, table_name, columns, already_loaded_t
         logger.info(f"Table {table_name} already loaded in this run. Skipping.")
         return cursor
 
+    target_table = shadow_table_name(table_name)
     current_time = time.strftime("%Y-%m-%d %H:%M:%S")
-    logger.info(f"{current_time} -- Loading {table_name} from {csv_file_path}.")
+    logger.info(f"{current_time} -- Loading {table_name} from {csv_file_path} into `{target_table}`.")
     columns_str = ', '.join(f'`{col}`' for col in columns)
     csv_file_path_escaped = csv_file_path.replace("\\", "\\\\")  # Escape for Windows if needed
 
     sql = (
         f"LOAD DATA LOCAL INFILE '{csv_file_path_escaped}' "
-        f"INTO TABLE `{table_name}` "
+        f"INTO TABLE `{target_table}` "
         "FIELDS TERMINATED BY ',' OPTIONALLY ENCLOSED BY '\"' "
         "LINES TERMINATED BY '\\n' "
         "IGNORE 1 LINES "
@@ -199,9 +251,9 @@ def load_table_once(cursor, csv_file_path, table_name, columns, already_loaded_t
     )
 
     cursor = execute_with_reconnect(cursor, sql)
-    cursor = execute_with_reconnect(cursor, f"SELECT COUNT(*) AS row_count FROM {table_name};")
+    cursor = execute_with_reconnect(cursor, f"SELECT COUNT(*) AS row_count FROM `{target_table}`;")
     row_count = cursor.fetchone()['row_count']
-    logger.info(f"{current_time} -- Data successfully loaded into {table_name}. Row count: {row_count}")
+    logger.info(f"{current_time} -- Data successfully loaded into `{target_table}`. Row count: {row_count}")
 
     already_loaded_tables.add(table_name)
     return cursor
@@ -240,17 +292,27 @@ def main(truncate_tables=True, skip_person_temp=False):
         # ------------------------------------------------------------------------------
         if truncate_tables:
             for table in all_tables:
-                sql = f"TRUNCATE TABLE `{table}`;"
-                cursor = execute_with_reconnect(cursor, sql)
+                if ATOMIC_SWAP and table in SWAP_TABLES:
+                    # Build into a shadow table instead of truncating the live one.
+                    # CREATE ... LIKE copies structure/indexes (no data); TRUNCATE
+                    # clears out any partial data left by a prior crashed run.
+                    create_sql = f"CREATE TABLE IF NOT EXISTS `{table}_new` LIKE `{table}`;"
+                    cursor = execute_with_reconnect(cursor, create_sql)
+                    truncate_sql = f"TRUNCATE TABLE `{table}_new`;"
+                    cursor = execute_with_reconnect(cursor, truncate_sql)
+                else:
+                    sql = f"TRUNCATE TABLE `{table}`;"
+                    cursor = execute_with_reconnect(cursor, sql)
             connection.commit()
 
-            # Disable keys once at the outset
+            # Disable keys once at the outset (on the shadow table when swapping)
             for table in all_tables:
-                disable_sql = f"ALTER TABLE `{table}` DISABLE KEYS;"
+                target = shadow_table_name(table)
+                disable_sql = f"ALTER TABLE `{target}` DISABLE KEYS;"
                 try:
                     cursor = execute_with_reconnect(cursor, disable_sql)
                 except Exception as e:
-                    logger.warning(f"Could not disable keys on {table}: {e}")
+                    logger.warning(f"Could not disable keys on {target}: {e}")
 
         already_loaded_tables = set()
 
@@ -381,11 +443,12 @@ def main(truncate_tables=True, skip_person_temp=False):
         # ------------------------------------------------------------------------------
         if truncate_tables:
             for table in all_tables:
-                enable_sql = f"ALTER TABLE `{table}` ENABLE KEYS;"
+                target = shadow_table_name(table)
+                enable_sql = f"ALTER TABLE `{target}` ENABLE KEYS;"
                 try:
                     cursor = execute_with_reconnect(cursor, enable_sql)
                 except Exception as e:
-                    logger.warning(f"Could not enable keys on {table}: {e}")
+                    logger.warning(f"Could not enable keys on {target}: {e}")
 
         # ------------------------------------------------------------------------------
         # (5) If we have person_temp, run update_person
@@ -425,3 +488,68 @@ def call_update_person_only():
             connection.close()
             connection = None
             logger.info("Database connection closed after call_update_person_only().")
+
+
+# ------------------------------------------------------------------------------
+#                swap_new_tables_into_place (Atomic Table Swap)
+# ------------------------------------------------------------------------------
+def swap_new_tables_into_place():
+    """Promote every `<table>_new` shadow table into its live name with a
+    single atomic RENAME TABLE statement, mirroring the "7. Atomic table
+    swap" step in setup/populateAnalysisSummaryTables_v2.sql.
+
+    No-op unless ATOMIC_SWAP=1. Must be called after the final identity merge
+    (call_update_person_only(), which updates person_new) has completed, so
+    the person table swapped into place already has firstName/lastName/etc.
+    populated -- call this from retrieveArticles.py's Step 6, after that call.
+
+    MySQL executes a multi-table RENAME TABLE atomically: either every listed
+    rename takes effect or none do. So a crash or error during the RENAME
+    itself leaves every live table exactly as it was before this call --
+    still serving the prior run's complete data. Everything before the
+    RENAME only ever touches `_new` shadow tables (or person_temp, which was
+    never live-reporting data), so a crash anywhere earlier in the nightly
+    run is equally harmless to the live tables.
+    """
+    if not ATOMIC_SWAP:
+        logger.info("ATOMIC_SWAP not enabled; skipping table swap (legacy truncate-in-place mode).")
+        return
+
+    global connection
+    connection = establish_connection()
+    cursor = connection.cursor()
+    try:
+        logger.info("7. Atomic table swap -- dropping any stale `_old` tables from a prior run.")
+        for t in SWAP_TABLES:
+            drop_sql = f"DROP TABLE IF EXISTS `{t}_old`;"
+            cursor = execute_with_reconnect(cursor, drop_sql)
+        connection.commit()
+
+        rename_sql = build_swap_rename_sql()
+        logger.info(f"Performing atomic RENAME to swap {len(SWAP_TABLES)} tables into place: {rename_sql}")
+        cursor = execute_with_reconnect(cursor, rename_sql)
+        connection.commit()
+        logger.info("Atomic table swap complete -- live tables now reflect tonight's rebuild.")
+
+        # The RENAME above already succeeded at this point: live tables are
+        # the new data. Dropping the now-stale `_old` tables is best-effort
+        # cleanup, not part of the atomicity guarantee -- a failure here is
+        # non-fatal and swept up by next run's pre-swap drop.
+        try:
+            for t in SWAP_TABLES:
+                drop_sql = f"DROP TABLE IF EXISTS `{t}_old`;"
+                cursor = execute_with_reconnect(cursor, drop_sql)
+            connection.commit()
+            logger.info("Dropped `_old` tables from this run.")
+        except Exception as cleanup_err:
+            logger.warning(f"Swap succeeded but failed to drop `_old` backup tables (non-fatal, cleaned up next run): {cleanup_err}")
+
+    except Exception as e:
+        logger.error(f"Atomic table swap FAILED -- live tables left untouched (prior run's data still serving): {e}")
+        raise
+    finally:
+        if connection and connection.open:
+            cursor.close()
+            connection.close()
+            connection = None
+            logger.info("Database connection closed after swap_new_tables_into_place().")

--- a/update/updateReciterDB.py
+++ b/update/updateReciterDB.py
@@ -44,6 +44,11 @@ connection = None
 # (env var on the reciterdb CronJob) once verified on dev.
 ATOMIC_SWAP = os.getenv("ATOMIC_SWAP", "0") == "1"
 
+# main() is called once per Analysis chunk (176 times in a measured nightly run),
+# so the shadow-table warning below is emitted only on the first call per process.
+# A warning that fires 176 times a night is a warning operators learn to ignore.
+_SWAP_WARNING_EMITTED = False
+
 # The 10 tables that participate in the atomic swap. person_temp is
 # deliberately excluded -- it is internal staging, always truncated and
 # loaded in place, never swapped.
@@ -285,7 +290,7 @@ def main(truncate_tables=True, skip_person_temp=False):
                            loads data, then re-enables keys at the end.
     :param skip_person_temp: If True, skip loading person_temp (and thus skip update_person).
     """
-    global connection
+    global connection, _SWAP_WARNING_EMITTED
     connection = establish_connection()
     cursor = connection.cursor()
 
@@ -476,7 +481,8 @@ def main(truncate_tables=True, skip_person_temp=False):
 
         connection.commit()
 
-        if ATOMIC_SWAP:
+        if ATOMIC_SWAP and not _SWAP_WARNING_EMITTED:
+            _SWAP_WARNING_EMITTED = True
             logger.warning(
                 "ATOMIC_SWAP=1: this run wrote to `<table>_new` SHADOW TABLES, not the "
                 "live tables. That data will NOT be visible to readers until "


### PR DESCRIPTION
## Problem

The nightly loader truncates the 11 core reporting tables at the start of the run and rebuilds them in place over the next ~43 minutes. Identity columns on `person` are only merged back at the very end (Step 6, `call_update_person_only()`).

The result is a daily window where the reporting DB is empty or partial while Publication Manager is reading it. Measured from the production cronjob logs:

| Date | tables truncated | Step 6 restores identity |
|---|---|---|
| 08-19 | 14:30:54 | 15:11:07 |
| 08-22 | 14:46:23 | 15:28:18 |
| 08-24 | 14:30:54 | 15:13:10 |

During that window `person` has 100% NULL `firstName`/`lastName`/`title`/`primaryEmail`/`primaryOrganizationalUnit`, and `/search` shows blank identities. The same window leaves `person_article` and the rest mid-rebuild.

The early `update_person` call at 14:30:54 is a no-op — it is an `UPDATE person JOIN person_temp` against a table truncated seconds earlier, so it matches zero rows and returns in 2ms. The real merge at 15:13 takes 1.1s.

This became user-visible when the cron schedule moved to 14:30 UTC (10:30am ET) on 2026-07-23. Before that the window fell overnight.

## Change

Build into `<table>_new` shadow tables and promote them with a single atomic `RENAME TABLE` at the end, so the live tables are never empty or partial at any instant. This is the pattern `setup/populateAnalysisSummaryTables_v2.sql` already uses for the summary tables ("7. Atomic table swap").

- `shadow_table_name()` routes every `LOAD DATA`, the `update_person` identity merge, the row-count `SELECT`, and the `DISABLE`/`ENABLE KEYS` loops to the shadow table.
- `swap_new_tables_into_place()` issues one 20-clause `RENAME TABLE` (live to `_old`, `_new` to live), then drops `_old`.
- Called from `retrieveArticles.py` **after** the Step 6 identity merge, so the promoted `person` already has identity columns populated.
- `person_temp` is excluded — it stays truncate-and-load in place.

Gated behind `ATOMIC_SWAP`, **defaulting off**. With the flag unset the behavior is the existing truncate-in-place path.

## Safety

- **Crash safety**: nothing but `person_temp` and the `_new` shadows is written before the `RENAME`. A crash at any earlier point leaves the live tables serving the previous run's complete data.
- **Foreign keys / triggers / views**: no FK in `setup/createDatabaseTableReciterDb.sql` references any of the 10 swap tables (the only FKs are on `admin_*`). There are no SQL triggers or views. Stored procedures resolve table names at execution time.
- **Disk**: the 10 tables total 2.11 GB / ~13.1M rows, so the shadows add ~2.1 GB at peak.
- **No other writers**: `retrieveNIH`, `retrieveReporter`, `abstractImport`, `conflictsImport`, `retrieveExternalArticles` and `nightlyIndexing` do not write to any of the 10 tables, so the swap cannot discard another script's writes.
- `retrieveS3.py` and `retrieveDynamoDb.py` call `main()` but deliberately do **not** auto-swap — a partial manual reload must not promote itself over a complete live table. With the flag on they emit a warning explaining that the data landed in shadow tables. That warning fires once per process, not once per `main()` call (`main()` runs 176 times in a measured nightly run).

## Tests

`update/test_atomic_swap.py` — DB-free, covers shadow-table routing and `RENAME` statement construction (single statement, correct clause ordering, all 10 tables, `person_temp` excluded, default-off).

## Before enabling in production

1. One full dev nightly with `ATOMIC_SWAP=1` at real data volume, verifying row counts and PM reads during the 14:30–15:13 UTC window.
2. Kill-test a mid-run crash and confirm the live tables still serve the prior run's data.
3. Query `information_schema` on prod for FKs/triggers/views on the 10 tables — the repo-based analysis cannot see objects created by hand.

Known limitation, pre-existing and unchanged by this PR: `main()` swallows exceptions, so a run with silently failed chunk loads would promote a partial build. Legacy behavior leaves a partial live table in the same situation. No completeness gate is added here.
