### PR TITLE
Align atomic table swap with the existing _backup/restore precedent

### DIFF
--- a/setup/restore_person_tables_from_backup.sql
+++ b/setup/restore_person_tables_from_backup.sql
@@ -1,3 +1,16 @@
+-- Rollback helper for the nightly loader's atomic table swap (ATOMIC_SWAP=1).
+-- Mirrors restore_from_backup_v2 (see populateAnalysisSummaryTables_v2.sql) but for the
+-- 10 person_* tables promoted by swap_new_tables_into_place() in update/updateReciterDB.py.
+-- The `_backup` tables persist until the NEXT run's pre-swap drop, so this can restore the
+-- previous run's data any time before then.
+--
+-- Apply with:  mysql --host=... --user=... --password=... reciterdb < this_file.sql
+-- Invoke with: CALL restore_person_tables_from_backup();
+
+DELIMITER //
+
+DROP PROCEDURE IF EXISTS `restore_person_tables_from_backup`//
+
 CREATE DEFINER=`admin`@`%` PROCEDURE `reciterdb`.`restore_person_tables_from_backup`()
 BEGIN
     DECLARE v_error INT DEFAULT 0;
@@ -38,4 +51,6 @@ BEGIN
     ELSE
         SELECT 'ERROR: Backup tables do not exist' AS status;
     END IF;
-END
+END//
+
+DELIMITER ;

--- a/setup/restore_person_tables_from_backup.sql
+++ b/setup/restore_person_tables_from_backup.sql
@@ -1,5 +1,5 @@
 -- Rollback helper for the nightly loader's atomic table swap (ATOMIC_SWAP=1).
--- Mirrors restore_from_backup_v2 (see populateAnalysisSummaryTables_v2.sql) but for the
+-- Mirrors restore_from_backup_v2 (setup/restore_from_backup_v2.sql) but for the
 -- 10 person_* tables promoted by swap_new_tables_into_place() in update/updateReciterDB.py.
 -- The `_backup` tables persist until the NEXT run's pre-swap drop, so this can restore the
 -- previous run's data any time before then.
@@ -9,15 +9,30 @@
 
 DELIMITER //
 
-DROP PROCEDURE IF EXISTS `restore_person_tables_from_backup`//
+DROP PROCEDURE IF EXISTS `reciterdb`.`restore_person_tables_from_backup`//
 
 CREATE DEFINER=`admin`@`%` PROCEDURE `reciterdb`.`restore_person_tables_from_backup`()
 BEGIN
     DECLARE v_error INT DEFAULT 0;
+    DECLARE v_backup_count INT DEFAULT 0;
     DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET v_error = 1;
 
-    -- Check if backup tables exist
-    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'person_backup' AND table_schema = DATABASE()) THEN
+    -- Require ALL 10 backup tables before touching anything. The sibling procedure
+    -- restore_from_backup_v2 guards on a single table; that is unsafe here because the
+    -- DROPs below are unconditional -- a partial backup set would destroy every live
+    -- table and then fail the RENAME, leaving nothing to restore.
+    SELECT COUNT(*) INTO v_backup_count
+    FROM information_schema.tables
+    WHERE table_schema = DATABASE()
+      AND table_name IN (
+        'person_backup','person_article_backup','person_article_author_backup',
+        'person_article_department_backup','person_article_grant_backup',
+        'person_article_keyword_backup','person_article_relationship_backup',
+        'person_article_scopus_target_author_affiliation_backup',
+        'person_article_scopus_non_target_author_affiliation_backup',
+        'person_person_type_backup');
+
+    IF v_backup_count = 10 THEN
 
         -- Drop current tables and rename backup to current
         DROP TABLE IF EXISTS person;
@@ -49,7 +64,8 @@ BEGIN
             SELECT 'ERROR: Failed to restore from backup' AS status;
         END IF;
     ELSE
-        SELECT 'ERROR: Backup tables do not exist' AS status;
+        SELECT CONCAT('ERROR: expected 10 backup tables, found ', v_backup_count,
+                      ' -- refusing to drop live tables') AS status;
     END IF;
 END//
 

--- a/setup/restore_person_tables_from_backup.sql
+++ b/setup/restore_person_tables_from_backup.sql
@@ -1,0 +1,41 @@
+CREATE DEFINER=`admin`@`%` PROCEDURE `reciterdb`.`restore_person_tables_from_backup`()
+BEGIN
+    DECLARE v_error INT DEFAULT 0;
+    DECLARE CONTINUE HANDLER FOR SQLEXCEPTION SET v_error = 1;
+
+    -- Check if backup tables exist
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'person_backup' AND table_schema = DATABASE()) THEN
+
+        -- Drop current tables and rename backup to current
+        DROP TABLE IF EXISTS person;
+        DROP TABLE IF EXISTS person_article;
+        DROP TABLE IF EXISTS person_article_author;
+        DROP TABLE IF EXISTS person_article_department;
+        DROP TABLE IF EXISTS person_article_grant;
+        DROP TABLE IF EXISTS person_article_keyword;
+        DROP TABLE IF EXISTS person_article_relationship;
+        DROP TABLE IF EXISTS person_article_scopus_target_author_affiliation;
+        DROP TABLE IF EXISTS person_article_scopus_non_target_author_affiliation;
+        DROP TABLE IF EXISTS person_person_type;
+
+        RENAME TABLE
+            person_backup TO person,
+            person_article_backup TO person_article,
+            person_article_author_backup TO person_article_author,
+            person_article_department_backup TO person_article_department,
+            person_article_grant_backup TO person_article_grant,
+            person_article_keyword_backup TO person_article_keyword,
+            person_article_relationship_backup TO person_article_relationship,
+            person_article_scopus_target_author_affiliation_backup TO person_article_scopus_target_author_affiliation,
+            person_article_scopus_non_target_author_affiliation_backup TO person_article_scopus_non_target_author_affiliation,
+            person_person_type_backup TO person_person_type;
+
+        IF v_error = 0 THEN
+            SELECT 'SUCCESS: Restored from backup tables' AS status;
+        ELSE
+            SELECT 'ERROR: Failed to restore from backup' AS status;
+        END IF;
+    ELSE
+        SELECT 'ERROR: Backup tables do not exist' AS status;
+    END IF;
+END

--- a/update/test_atomic_swap.py
+++ b/update/test_atomic_swap.py
@@ -77,23 +77,43 @@ def test_build_swap_rename_sql_is_single_statement():
 def test_build_swap_rename_sql_covers_every_swap_table_both_directions():
     sql = u.build_swap_rename_sql()
     for t in u.SWAP_TABLES:
-        assert f"`{t}` TO `{t}_old`" in sql, f"{t} -> {t}_old clause missing"
+        assert f"`{t}` TO `{t}_backup`" in sql, f"{t} -> {t}_backup clause missing"
         assert f"`{t}_new` TO `{t}`" in sql, f"{t}_new -> {t} clause missing"
     # And nothing else snuck in.
     assert "person_temp" not in sql
 
 
 def test_build_swap_rename_sql_matches_ticket_form():
-    # Verbatim shape requested: RENAME TABLE person TO person_old,
-    # person_new TO person, person_article TO person_article_old, ... ;
+    # Verbatim shape requested: RENAME TABLE person TO person_backup,
+    # person_new TO person, person_article TO person_article_backup, ... ;
+    # Matches the naming precedent in setup/populateAnalysisSummaryTables_v2.sql
+    # ("7. Atomic table swap") -- `_backup`, not `_old`.
     sql = u.build_swap_rename_sql()
-    person_idx = sql.index("`person` TO `person_old`")
+    person_idx = sql.index("`person` TO `person_backup`")
     person_new_idx = sql.index("`person_new` TO `person`")
-    person_article_idx = sql.index("`person_article` TO `person_article_old`")
+    person_article_idx = sql.index("`person_article` TO `person_article_backup`")
     assert person_idx < person_new_idx < person_article_idx, (
-        "clause order must be: person->person_old, person_new->person, "
-        "person_article->person_article_old, ..."
+        "clause order must be: person->person_backup, person_new->person, "
+        "person_article->person_article_backup, ..."
     )
+
+
+def test_build_swap_rename_sql_maps_each_live_table_to_backup_and_each_new_table_to_live():
+    # Explicit statement of the RENAME's meaning for every one of the 10
+    # SWAP_TABLES: `<table>` -> `<table>_backup` and `<table>_new` -> `<table>`,
+    # all within the single statement (not per-table separate RENAMEs).
+    sql = u.build_swap_rename_sql()
+    assert sql.count("RENAME TABLE") == 1
+    for t in u.SWAP_TABLES:
+        live_to_backup = f"`{t}` TO `{t}_backup`"
+        new_to_live = f"`{t}_new` TO `{t}`"
+        assert live_to_backup in sql, f"missing live->backup mapping for {t}"
+        assert new_to_live in sql, f"missing new->live mapping for {t}"
+        # The live->backup clause for this table must precede its new->live
+        # clause, matching the precedent's per-table pair ordering.
+        assert sql.index(live_to_backup) < sql.index(new_to_live), (
+            f"{t}: expected `{t}` TO `{t}_backup` before `{t}_new` TO `{t}`"
+        )
 
 
 if __name__ == "__main__":
@@ -105,4 +125,5 @@ if __name__ == "__main__":
     test_build_swap_rename_sql_is_single_statement()
     test_build_swap_rename_sql_covers_every_swap_table_both_directions()
     test_build_swap_rename_sql_matches_ticket_form()
+    test_build_swap_rename_sql_maps_each_live_table_to_backup_and_each_new_table_to_live()
     print("OK: shadow-table routing and RENAME TABLE construction verified (no DB).")

--- a/update/updateReciterDB.py
+++ b/update/updateReciterDB.py
@@ -36,8 +36,8 @@ connection = None
 # retrieveArticles.py after the final identity merge). This removes the daily
 # window where the live tables are empty/partial while being read for
 # reporting. Mirrors the pattern in setup/populateAnalysisSummaryTables_v2.sql
-# ("7. Atomic table swap"), adapted to Python/pymysql and to `_old`/immediate
-# drop instead of that script's `_backup`/next-run drop.
+# ("7. Atomic table swap"), adapted to Python/pymysql -- same `_backup`
+# naming and next-run drop as that script.
 #
 # Default OFF: this is the core nightly loader and this branch has not been
 # exercised against a real database. Opt in explicitly with ATOMIC_SWAP=1
@@ -89,10 +89,10 @@ def shadow_table_name(table_name):
 def build_swap_rename_sql():
     """Build the single atomic RENAME TABLE statement that promotes every
     `_new` shadow table into its live name, moving the current live table to
-    `_old` in the same statement. Pure string construction, no DB access."""
+    `_backup` in the same statement. Pure string construction, no DB access."""
     clauses = []
     for t in SWAP_TABLES:
-        clauses.append(f"`{t}` TO `{t}_old`")
+        clauses.append(f"`{t}` TO `{t}_backup`")
         clauses.append(f"`{t}_new` TO `{t}`")
     return "RENAME TABLE " + ", ".join(clauses) + ";"
 
@@ -555,9 +555,9 @@ def swap_new_tables_into_place():
     connection = establish_connection()
     cursor = connection.cursor()
     try:
-        logger.info("7. Atomic table swap -- dropping any stale `_old` tables from a prior run.")
+        logger.info("7. Atomic table swap -- dropping any stale `_backup` tables from the prior run.")
         for t in SWAP_TABLES:
-            drop_sql = f"DROP TABLE IF EXISTS `{t}_old`;"
+            drop_sql = f"DROP TABLE IF EXISTS `{t}_backup`;"
             cursor = execute_with_reconnect(cursor, drop_sql)
         connection.commit()
 
@@ -567,18 +567,11 @@ def swap_new_tables_into_place():
         connection.commit()
         logger.info("Atomic table swap complete -- live tables now reflect tonight's rebuild.")
 
-        # The RENAME above already succeeded at this point: live tables are
-        # the new data. Dropping the now-stale `_old` tables is best-effort
-        # cleanup, not part of the atomicity guarantee -- a failure here is
-        # non-fatal and swept up by next run's pre-swap drop.
-        try:
-            for t in SWAP_TABLES:
-                drop_sql = f"DROP TABLE IF EXISTS `{t}_old`;"
-                cursor = execute_with_reconnect(cursor, drop_sql)
-            connection.commit()
-            logger.info("Dropped `_old` tables from this run.")
-        except Exception as cleanup_err:
-            logger.warning(f"Swap succeeded but failed to drop `_old` backup tables (non-fatal, cleaned up next run): {cleanup_err}")
+        # The RENAME above already moved the previous live tables to
+        # `_backup`. Leave them in place -- they are NOT dropped here.
+        # This run's `_backup` tables serve as a rollback window (see
+        # setup/restore_person_tables_from_backup.sql) until the next run's
+        # pre-swap drop above clears them to make room for the next backup.
 
     except Exception as e:
         logger.error(f"Atomic table swap FAILED -- live tables left untouched (prior run's data still serving): {e}")


### PR DESCRIPTION
Follow-up to #149 / #150. Brings the atomic table swap into line with the pattern this repo already uses for the `analysis_summary_*` tables, instead of the near-miss variant that shipped.

## Why

The swap that landed in #149/#150 reinvented an existing pattern in a worse form. `setup/populateAnalysisSummaryTables_v2.sql` ("STEP 7: ATOMIC TABLE SWAP", ~line 1254) and `setup/restore_from_backup_v2.sql` already establish how this is done here.

| | precedent | what shipped | this PR |
|---|---|---|---|
| naming | `_backup` | `_old` | `_backup` |
| retention | dropped at the start of the **next** run — a full day of rollback | dropped immediately after the swap | dropped at the start of the next run |
| rollback | `restore_from_backup_v2()` | none — backup already gone | `restore_person_tables_from_backup()` |

No behavior is at risk: `ATOMIC_SWAP` defaults off and the swap has never executed in any environment.

## Changes

1. `_old` → `_backup` throughout `update/updateReciterDB.py`, including comments and log strings.
2. The post-swap drop block is deleted. The pre-swap drop remains, so this run's backups survive until the next run clears them.
3. New `setup/restore_person_tables_from_backup.sql` — a one-call rollback procedure for the 10 swapped tables, mirroring `restore_from_backup_v2`.

## Two deliberate deviations from the precedent

**The file is runnable.** `restore_from_backup_v2.sql` and `cleanup_staging_tables_v2.sql` are bare `CREATE PROCEDURE` bodies with no `DELIMITER` handling — piping either to the mysql client breaks at the first `;` inside the body. (`restore_from_backup_v2`'s real definition lives in `populateAnalysisSummaryTables_v2.sql:1418`; the standalone file is a redundant export.) This file uses the runnable convention — `DELIMITER //`, `DROP PROCEDURE IF EXISTS`, `END//` — and documents its apply/invoke commands in the header.

**The guard requires all 10 backups, not one.** `restore_from_backup_v2` checks a single table's existence and then drops its whole set unconditionally. Applied to 10 tables that is unsafe: a partial backup set drops every live table, then fails the RENAME, leaving nothing to restore — in the one procedure you run when already in trouble. This counts all 10 first and refuses otherwise, reporting how many it found.

That second deviation was verified against the dev database:

```
-- with 1 of 10 backups present (the exact case the single-table guard accepts)
CALL restore_person_tables_from_backup();
ERROR: expected 10 backup tables, found 1 -- refusing to drop live tables
-- all 10 live tables intact, 24,403 rows unchanged
```

## Deployment

Stored procedures are not shipped by the image build, so this lands in four places. The two database applies are already done:

- [x] dev database `reciterdb` — applied, procedure verified, refusal tested at 0 and 1 backups with no data touched
- [x] prod database `reciterdb` — applied and verified; `restore_from_backup_v2` untouched, `person` unchanged at 33,146 rows
- [ ] this PR (`master`)
- [ ] companion PR (`dev`)

Verified `lower_case_table_names=0` on prod, so the pre-existing `person_article_author_BACKUP` (uppercase, ~32.9M rows) does not count toward the guard's total.

## Tests

`update/test_atomic_swap.py` updated to assert the `_backup` naming in both rename directions. The restore SQL's table list and guard list are both cross-checked against `SWAP_TABLES`.
