### PR TITLE
fix(#158): make authorship_review.dup_flag a per-authorship test, not a per-article one

### DIFF
--- a/setup/fix_authorship_review_dup_flag_v2.4.sql
+++ b/setup/fix_authorship_review_dup_flag_v2.4.sql
@@ -1,0 +1,48 @@
+-- #158 remediation: clear the per-article dup_flag chips already written to
+-- authorship_review.
+--
+-- The code fix makes dup_flag a per-authorship test going forward, but it does
+-- NOT heal the rows already in the table. dup_flag/dup_reason are in
+-- aar_db._REFRESH_COLS, so they are rewritten whenever the producer re-emits a
+-- row -- but the scopus lane's recurring sweep is a rolling ORIG-LOAD-DATE
+-- window [today-90d, today-14d], and Scopus load date is immutable per
+-- document. Once a document falls out of that window it never re-enters, so its
+-- row is never re-emitted. recheck_open_scopus() revisits old rows but only
+-- writes status/resolved_at/note, never dup_flag. 98% of the wrong chips were
+-- first seen in the 2026-07-04/05 --mode initial backfill, whose load dates run
+-- 2021-05..2026-05 -- permanently outside the rolling window.
+--
+-- So without this UPDATE the reported symptom stays on screen indefinitely.
+--
+-- Measured on prod 2026-08-28, immediately before writing this file:
+--   dup_flag=1 rows                        2,642
+--   of those, dup_reason names a uid that
+--   is NOT a candidate on its own row      1,349  (51.1%)
+--   of those wrong chips, status='open'      735
+--   correct chips that are currently open      0
+-- i.e. every dup_flag=1 row in a curator's queue today is a false positive.
+--
+-- The predicate is the SQL twin of aar_db.dup_uid_for_authorship(): a chip
+-- survives only if the uid it names is this row's top_cwid or appears in its
+-- candidate_cwids_json. Correct chips (1,293 rows, none of them open) are left
+-- untouched rather than blanket-cleared.
+--
+-- Run against dev first, then prod. Idempotent -- re-running matches nothing.
+
+-- Dry run first; expect the same counts as the UPDATE reports.
+-- SELECT COUNT(*) AS n, SUM(status='open') AS n_open
+-- FROM authorship_review
+-- WHERE dup_flag = 1
+--   AND JSON_SEARCH(candidate_cwids_json, 'one',
+--         SUBSTRING_INDEX(SUBSTRING_INDEX(dup_reason, 'for ', -1), ' (DOI', 1)) IS NULL
+--   AND (top_cwid IS NULL
+--        OR top_cwid <> SUBSTRING_INDEX(SUBSTRING_INDEX(dup_reason, 'for ', -1), ' (DOI', 1));
+
+UPDATE authorship_review
+SET dup_flag = 0,
+    dup_reason = NULL
+WHERE dup_flag = 1
+  AND JSON_SEARCH(candidate_cwids_json, 'one',
+        SUBSTRING_INDEX(SUBSTRING_INDEX(dup_reason, 'for ', -1), ' (DOI', 1)) IS NULL
+  AND (top_cwid IS NULL
+       OR top_cwid <> SUBSTRING_INDEX(SUBSTRING_INDEX(dup_reason, 'for ', -1), ' (DOI', 1));

--- a/setup/table_authorship_review.sql
+++ b/setup/table_authorship_review.sql
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `n_candidates`           INT          NULL,
   `single_candidate`       TINYINT(1)   NULL,                -- cohort_size == 1
   `candidate_cwids_json`   LONGTEXT     NULL,                -- ranked alternates
-  `dup_flag`               TINYINT(1)   NOT NULL DEFAULT 0,  -- matches an external_article by DOI
+  `dup_flag`               TINYINT(1)   NOT NULL DEFAULT 0,  -- external_article DOI match, restricted to this authorship's candidates
   `dup_reason`             VARCHAR(255) NULL,                -- e.g. "Already added as ExternalArticle for <uid> (DOI match)"
   `status`                 ENUM('open','assigned','accepted','rejected','dismissed','snoozed')
                                         NOT NULL DEFAULT 'open',   -- curator state

--- a/update/aar_db.py
+++ b/update/aar_db.py
@@ -138,17 +138,26 @@ def upsert(rows):
 
 
 def dup_flags_by_doi(dois):
-    """doi -> (uid, article_id) for DOIs already present in reciterdb `external_article`
-    (the nightly ExternalArticle projection, update/retrieveExternalArticles.py, which
-    runs before the weekly AAR lane). Lives here (not aar_orchestrator.py) so both the
-    PubMed lane (aar_orchestrator._db_rows) and the self-contained Scopus lane
-    (aar_universe_scopus, which deliberately avoids importing the xgboost/S3-heavy
-    PubMed-lane modules) can call it without a heavier import.
+    """doi -> {uid, ...}: EVERY person a DOI is already added for in reciterdb
+    `external_article` (the nightly ExternalArticle projection,
+    update/retrieveExternalArticles.py, which runs before the weekly AAR lane). Lives
+    here (not aar_orchestrator.py) so both the PubMed lane (aar_orchestrator._db_rows)
+    and the self-contained Scopus lane (aar_universe_scopus, which deliberately avoids
+    importing the xgboost/S3-heavy PubMed-lane modules) can call it without a heavier
+    import.
 
     Used to precompute authorship_review.dup_flag/dup_reason at producer time, so a
     curator sees an "already added" heads-up before spending a click on Accept/Assign.
     The live 409 conflict check at Accept/Assign time (Publication Manager) stays as
     the final same-day-race safety net — this is a heads-up, not a replacement.
+
+    The FULL uid set per DOI, never one arbitrary uid: `authorship_review` is one row
+    per AUTHORSHIP, so the heads-up is only true when the article is already added for
+    a person who is a candidate for THAT authorship. Callers hand the set to
+    dup_uid_for_authorship() to intersect it with the row's own candidates. Returning
+    the first uid seen (what this did before issue #158) made every co-author of an
+    already-added paper look like a duplicate of somebody else's authorship. The
+    article_id half of that old tuple went with it — neither lane ever read it.
 
     Batched (500 DOIs/query) rather than one unbounded IN-clause, same convention as
     aar_gate.attributed_pmids / this module's own upsert() chunking. Read-only.
@@ -161,14 +170,33 @@ def dup_flags_by_doi(dois):
     out = {}
     if not dois:
         return out
-    stmt = text("SELECT doi, uid, article_id FROM external_article WHERE doi IN :ds") \
+    stmt = text("SELECT doi, uid FROM external_article WHERE doi IN :ds") \
         .bindparams(bindparam("ds", expanding=True))
     with engine().connect() as c:
         for i in range(0, len(dois), 500):
             chunk = dois[i:i + 500]
-            for doi, uid, article_id in c.execute(stmt, {"ds": chunk}):
-                out.setdefault(doi.lower(), (uid, article_id))
+            for doi, uid in c.execute(stmt, {"ds": chunk}):
+                out.setdefault(doi.lower(), set()).add(uid)
     return out
+
+
+def dup_uid_for_authorship(dup_map, doi, top, cands):
+    """The candidate for THIS authorship whose ExternalArticle already covers `doi`,
+    or None — the per-authorship duplicate test both lanes use to set dup_flag/
+    dup_reason. Candidates are the row's own top_cwid plus every cwid that goes into
+    candidate_cwids_json, tested top-first so dup_reason names the person the row
+    actually proposes when more than one candidate matches.
+
+    Article-level "this paper is already in the system for somebody" is deliberately
+    not surfaced (issue #158): on a per-authorship row a "Possible duplicate" chip
+    naming an unrelated co-author reads as "already handled" and sends a curator past
+    work that is genuinely open."""
+    uids = (dup_map or {}).get(doi.lower()) if doi else None
+    if not uids:
+        return None
+    cwids = [top["cwid"]] if top else []
+    cwids += [c.get("cwid") for c in cands or ()]
+    return next((c for c in cwids if c in uids), None)
 
 
 def _describe():

--- a/update/aar_orchestrator.py
+++ b/update/aar_orchestrator.py
@@ -158,7 +158,10 @@ def _db_rows(resolved_auth, run_date):
     true cohort size (unique surname+initial), the strongest precision signal.
 
     dup_flag/dup_reason: one batched aar_db.dup_flags_by_doi() call over every DOI in
-    this run's resolved_auth (not a query per row) — see that function's docstring."""
+    this run's resolved_auth (not a query per row), narrowed per row to THIS
+    authorship's own candidates by aar_db.dup_uid_for_authorship — a co-author's
+    already-added authorship must not flag this one (issue #158). See those
+    functions' docstrings."""
     dois = {a.get("doi") for a, i, n, au, cands, top in resolved_auth if a.get("doi")}
     dup_map = aar_db.dup_flags_by_doi(dois) if dois else {}
     out = []
@@ -170,7 +173,7 @@ def _db_rows(resolved_auth, run_date):
                else "suggested" if fg >= gate.STORAGE_THRESHOLD else "buried")
         cohort = top.get("cohort_size")
         doi = a.get("doi")
-        dup_hit = dup_map.get(doi.lower()) if doi else None
+        dup_uid = aar_db.dup_uid_for_authorship(dup_map, doi, top, cands)
         out.append({
             "source": "pubmed",
             "pmid": a["pmid"],
@@ -192,9 +195,9 @@ def _db_rows(resolved_auth, run_date):
             "top_affil_match": int(bool(top["affil_dept_match"])),
             "n_candidates": len(cands), "single_candidate": int(cohort == 1),
             "candidate_cwids_json": json.dumps(_compact(cands)),
-            "dup_flag": int(bool(dup_hit)),
-            "dup_reason": (f"Already added as ExternalArticle for {dup_hit[0]} (DOI match)"
-                           if dup_hit else None),
+            "dup_flag": int(bool(dup_uid)),
+            "dup_reason": (f"Already added as ExternalArticle for {dup_uid} (DOI match)"
+                           if dup_uid else None),
             "status": "open", "first_seen": run_date,
             "last_checked": run_date, "last_refreshed": run_date,
         })

--- a/update/aar_universe_scopus.py
+++ b/update/aar_universe_scopus.py
@@ -378,9 +378,11 @@ def _build_row(entry, i, n, author, top, cands, run_ts, dup_map=None):
     cohort = top.get("cohort_size") if top else None
     # dup_flag/dup_reason: heads-up "already added as ExternalArticle" signal, joined
     # by DOI against reciterdb.external_article (aar_db.dup_flags_by_doi, batched once
-    # per run() call, not per row — see that function's docstring). Live 409 at
-    # Accept/Assign time (Publication Manager) remains the final same-day-race check.
-    dup_hit = (dup_map or {}).get(doi.lower()) if doi else None
+    # per run() call, not per row — see that function's docstring) and then narrowed to
+    # THIS authorship's own candidates, so a co-author's already-added authorship never
+    # flags this one (issue #158). Live 409 at Accept/Assign time (Publication Manager)
+    # remains the final same-day-race check.
+    dup_uid = aar_db.dup_uid_for_authorship(dup_map, doi, top, cands)
     return {
         "source": "scopus", "pmid": None,
         # numeric Scopus record id -> the PM Accept builds articleId "SCOPUS:<external_id>"
@@ -411,9 +413,9 @@ def _build_row(entry, i, n, author, top, cands, run_ts, dup_map=None):
         "top_affil_match": int(bool(top["affil_dept_match"])) if top else None,
         "n_candidates": len(cands), "single_candidate": int(cohort == 1) if cohort else None,
         "candidate_cwids_json": json.dumps(_compact(cands)),
-        "dup_flag": int(bool(dup_hit)),
-        "dup_reason": (f"Already added as ExternalArticle for {dup_hit[0]} (DOI match)"
-                       if dup_hit else None),
+        "dup_flag": int(bool(dup_uid)),
+        "dup_reason": (f"Already added as ExternalArticle for {dup_uid} (DOI match)"
+                       if dup_uid else None),
         "status": "open", "first_seen": run_ts,
         "last_checked": run_ts, "last_refreshed": run_ts,
     }
@@ -686,11 +688,32 @@ def _selftest():
     check("row dup_flag=0/dup_reason=None with no dup_map (default)",
           row["dup_flag"] == 0 and row["dup_reason"] is None)
 
+    # issue #158: dup_flag is per-AUTHORSHIP. A DOI already added for someone who is
+    # not a candidate for this authorship (a co-author on the same paper) is not a
+    # duplicate of this row.
+    row_other = _build_row(entry, i, n, au, top, [top], "2026-07-03 00:00:00",
+                           dup_map={"10.1/x": {"him4004"}})
+    check("row dup_flag=0 when the DOI was added for a NON-candidate (co-author)",
+          row_other["dup_flag"] == 0 and row_other["dup_reason"] is None)
+
     row_dup = _build_row(entry, i, n, au, top, [top], "2026-07-03 00:00:00",
-                         dup_map={"10.1/x": ("abc1234", "SCOPUS:105037523511")})
-    check("row dup_flag=1 and dup_reason names the uid when the DOI is in dup_map",
+                         dup_map={"10.1/x": {"js1"}})
+    check("row dup_flag=1 and dup_reason names the candidate the DOI was added for",
           row_dup["dup_flag"] == 1 and row_dup["dup_reason"]
-          == "Already added as ExternalArticle for abc1234 (DOI match)")
+          == "Already added as ExternalArticle for js1 (DOI match)")
+
+    alt = dict(top, cwid="jd2", name="Jane Doe")
+    row_alt = _build_row(entry, i, n, au, top, [top, alt], "2026-07-03 00:00:00",
+                         dup_map={"10.1/x": {"him4004", "jd2"}})
+    check("row dup_flag=1 off an alternate candidate, and dup_reason names that "
+          "candidate rather than the unrelated co-author",
+          row_alt["dup_flag"] == 1 and row_alt["dup_reason"]
+          == "Already added as ExternalArticle for jd2 (DOI match)")
+
+    row_both = _build_row(entry, i, n, au, top, [top, alt], "2026-07-03 00:00:00",
+                          dup_map={"10.1/x": {"js1", "jd2"}})
+    check("dup_reason names the top candidate when several candidates match",
+          row_both["dup_reason"] == "Already added as ExternalArticle for js1 (DOI match)")
 
     check("_authors_json returns '[]' (not null) when the document has no author field",
           _authors_json({}) == "[]")


### PR DESCRIPTION
dup_flag was computed per ARTICLE: dup_flags_by_doi() returned one arbitrary
uid per DOI and both lanes stamped it onto every authorship row sharing that
DOI. On a multi-WCM-author paper where one author's authorship had already
been added as an ExternalArticle, every co-author's authorship was chipped
"Possible duplicate" — telling a curator that genuinely open work was already
handled.

dup_flags_by_doi now returns the full uid set per DOI (the old setdefault
silently kept only the first row, and article_id was never read by either
lane). New aar_db.dup_uid_for_authorship() intersects that set with the row's
own candidates — top_cwid first, then candidate_cwids_json — so the flag only
fires when the article is already added for a person this authorship actually
proposes, and dup_reason names that person rather than an unrelated co-author.

Both lanes get it: aar_universe_scopus._build_row and aar_orchestrator._db_rows.
No schema change. Note the PubMed lane's share is currently zero — all 2,642
dup_flag=1 rows are source='scopus'; external_article holds no PubMed-reachable
rows yet — so the impact numbers below are scopus-only.

Existing rows do NOT self-heal, and need setup/fix_authorship_review_dup_flag_v2.4.sql.
dup_flag/dup_reason are in _REFRESH_COLS, so they are rewritten when the
producer re-emits a row — but the scopus sweep is a rolling ORIG-LOAD-DATE
window [today-90d, today-14d] and Scopus load date is immutable per document,
so a row that falls out never re-enters. recheck_open_scopus() revisits old
rows but only writes status/resolved_at/note. 98% of the wrong chips came from
the 2026-07-04/05 --mode initial backfill, whose load dates are permanently
outside the window.

Measured on prod 2026-08-28: 2,642 rows carry dup_flag=1; 1,349 (51.1%) name a
uid that is not a candidate on their own row; 735 of those are status='open',
and there are zero correct chips currently open — every dup_flag=1 row in a
curator's queue today is a false positive. Against the current external_article
snapshot the new rule is a strict subset of the old: 1,380 fewer rows flagged,
0 newly flagged. The issue's example (ids 16642/16643/16644) resolves exactly —
him4004 keeps its flag, zliu and jig2001 lose theirs.

The article-level "this paper is in the system for somebody" signal is dropped
rather than relocated to a new column: nobody has asked for it, and it would
cost a migration plus a PM UI change.

## Verification

- `python3 update/aar_universe_scopus.py --selftest` → 31 checks, SELFTEST PASS, including 5 new dup cases (non-candidate DOI hit → 0; candidate hit → 1 naming that candidate; alternate-candidate hit names the right person; top-first when several match).
- Blast radius measured read-only against prod, reproduced by two independent routes (a replay through the new `dup_uid_for_authorship` and a pure-SQL `JSON_SEARCH` predicate) that agree exactly: 1,349 wrong + 1,293 right = 2,642.
- Adversarially reviewed on four lenses (correctness / regression / evidence / over-engineering). The evidence lens caught that an earlier draft of this commit message claimed the existing rows would self-heal on the next producer run — they will not, which is why `setup/fix_authorship_review_dup_flag_v2.4.sql` is in this PR.

## Reviewer notes

1. The remediation SQL is **not applied**. Run it against dev, then prod. It carries a commented-out dry-run SELECT with the same predicate.
2. `article_id` was dropped from `dup_flags_by_doi`'s SELECT — neither lane ever read it.
3. `dup_reason`'s wording is unchanged, so anything parsing that string still works; only the uid it names changes.
4. The article-level signal is dropped, not relocated. If it is wanted back as a separate field, that is a new issue.

Closes #158