### PR TITLE
fix(#157): persist isbn, and make _normalize_issn idempotent so the ISSN pre-filter can actually fire

### DIFF
--- a/setup/alter_authorship_review_add_isbn_v2.3.sql
+++ b/setup/alter_authorship_review_add_isbn_v2.3.sql
@@ -1,0 +1,72 @@
+-- =============================================================================
+-- Migration: authorship_review add isbn (v2.3)
+-- =============================================================================
+-- Adds:
+--   - isbn   VARCHAR(128) NULL  — comma-joined ISBN list (Scopus returns several per
+--                                 book: print/ebook editions, ISBN-10 and ISBN-13).
+--                                 The producer joins _extract_isbns() with ','; the
+--                                 recheck splits on ',' — no comma inside an ISBN.
+--
+-- WHY THIS MIGRATION EXISTS:
+--   Book-like Scopus documents are ISBN-keyed, not journal-keyed: they carry no
+--   prism:issn at all, so the `issn` column added in v2.1 is structurally NULL for
+--   them and the dead-journal pre-filter can never reach them. They are most of the
+--   queue — measured on prod 2026-08-28, Book Chapter + Book + Editorial are 573 of
+--   the 729 open no-DOI scopus rows (79%), and 15/15 sampled documents of each of
+--   those three types carried an ISBN.
+--
+--   resolve_no_doi() has taken an `isbns` argument since v2.1 and the ingest path
+--   (run(), which still holds the raw Scopus doc) passes it. recheck_open_scopus()
+--   could not: it works from the stored row, and there was no column to store the
+--   ISBN in, so it silently passed the default None and every backlog row fell
+--   through to the title search. This column closes that ingest/recheck asymmetry —
+--   the same asymmetry v2.1 closed for ISSN. See issue #157.
+--
+--   SIZE THE BENEFIT HONESTLY BEFORE APPLYING. resolve_no_doi consults ISBN only for
+--   pub_type='Book' (18 of the 729 rows), and a live probe on 2026-08-28 found 0 of
+--   53 sampled ISBN-carrying backlog documents (18 Book, 25 Book Chapter, 10
+--   Editorial) hit PubMed on ANY of their ISBNs — the current backlog is the residue
+--   the weekly recheck has already failed to resolve, so this column buys ~0
+--   dismissals on it TODAY. Its value is forward-looking (new Book rows get the same
+--   check at recheck time that ingest already applies — the ingest probe of
+--   2026-08-14, n=26, resolved 3.8% on ISBN alone) plus the stored identifier itself,
+--   which is the only venue id a book-like row ever has.
+--
+--   The fresh-build schema (setup/table_authorship_review.sql) is updated in the same
+--   PR. This migration brings EXISTING databases up to that schema. It must be applied
+--   directly to BOTH reciterdb instances — the producer instance and the separate dev
+--   instance behind reciter-pm-dev (loaded manually) — same as v1.6, v2.1 and v2.2.
+--   Merging the PR does NOT run DDL.
+--
+-- DURABILITY: authorship_review is curator state, not a reporting export — not in
+--   update/updateReciterDB.py's truncate list, not touched by any nightly ETL step.
+--
+-- Additive only, guarded by an information_schema check (no-op on re-run). Existing
+-- rows get isbn=NULL; the producer fills it on the next upsert of a given row. Rows
+-- from the one-time 2026-07-05 --mode initial backfill are never re-swept by the
+-- recurring cron (it sweeps a recent ORIG-LOAD-DATE window only), so they need
+-- update/targeted_authors_backfill.py --apply, which looks each document up by its
+-- stored doi/external_id and fills issn/isbn in place.
+-- =============================================================================
+
+SET @db = DATABASE();
+
+-- -----------------------------------------------------------------------------
+-- isbn VARCHAR(128) NULL — comma-joined ISBN list
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'isbn') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `isbn` VARCHAR(128) NULL',
+    'SELECT ''authorship_review.isbn already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+SELECT column_name, data_type, character_maximum_length, is_nullable
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'authorship_review'
+  AND column_name = 'isbn';

--- a/setup/table_authorship_review.sql
+++ b/setup/table_authorship_review.sql
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `title`                  TEXT         NULL,
   `journal`                VARCHAR(512) NULL,
   `issn`                   VARCHAR(9)   NULL,                -- hyphenated NNNN-NNNC, scopus only
+  `isbn`                   VARCHAR(128) NULL,                -- comma-joined ISBNs, scopus book-like only
   `doi`                    VARCHAR(255) NULL,
   `authors_json`           LONGTEXT     NULL,                -- Scopus full author list, scopus only
   `classification`         ENUM('assigned','suggested','buried','absent') NULL,

--- a/update/aar_db.py
+++ b/update/aar_db.py
@@ -30,7 +30,7 @@ TABLE = "authorship_review"
 _REFRESH_COLS = [
     "source", "external_id", "pub_type", "container_id",
     "author_position", "author_position_label", "wcm_author", "author_affiliation",
-    "entrez_date", "title", "journal", "issn", "doi", "authors_json", "classification",
+    "entrez_date", "title", "journal", "issn", "isbn", "doi", "authors_json", "classification",
     "top_cwid", "top_name", "top_person_type", "top_dept",
     "top_fg_score", "top_io_score", "top_confidence", "top_cohort_size",
     "top_given_match", "top_affil_match", "n_candidates", "single_candidate",
@@ -70,6 +70,7 @@ CREATE TABLE IF NOT EXISTS {TABLE} (
   title                  TEXT         NULL,
   journal                VARCHAR(512) NULL,
   issn                   VARCHAR(9)   NULL,
+  isbn                   VARCHAR(128) NULL,
   doi                    VARCHAR(255) NULL,
   authors_json           LONGTEXT     NULL,
   classification         ENUM('assigned','suggested','buried','absent') NULL,

--- a/update/aar_universe_scopus.py
+++ b/update/aar_universe_scopus.py
@@ -141,7 +141,19 @@ def issn_in_pubmed(issn):
     '"9999-9999"[All Fields]'. So a non-zero count alone isn't enough;
     querytranslation must actually show [Journal] or the "hit" is meaningless.
     Returns None (not False) whenever the ISSN is missing/malformed/unrecognized, so
-    callers don't mistake "we can't check" for "confirmed absent"."""
+    callers don't mistake "we can't check" for "confirmed absent".
+
+    CONSEQUENCE, measured 2026-08-28 (issue #157) and left deliberately in place: on
+    the open no-DOI backlog this returns True or None but essentially never False, so
+    the pre-filter almost never short-circuits. All 21 distinct ISSNs among those rows
+    came back either [Journal]-recognized with a non-zero count (14, -> True) or with
+    no [Journal] translation at all (7, -> None). Only a venue PubMed recognizes as a
+    journal AND holds zero articles for yields False, which is close to an empty set.
+    Making "well-formed but unrecognized" mean False WOULD fire on that second group
+    and is the safe direction (a False keeps the row open rather than dismissing it),
+    but it trades away the guard that this docstring's GOTCHA paragraph exists for.
+    That is a deliberate call for a human, not a silent change: don't "fix" this
+    without re-reading the gotcha above."""
     hyphenated = _normalize_issn(issn)
     if not hyphenated:
         return None
@@ -206,9 +218,19 @@ def resolve_no_doi(title, author_last, pub_type, issn, isbns=None):
 def _normalize_issn(issn):
     """Scopus gives ISSN unhyphenated (e.g. '0732183X'); PubMed's [issn] tag and the
     authorship_review.issn column both want hyphenated NNNN-NNNC. Returns None for
-    anything that isn't exactly 8 chars (missing/malformed — stored as NULL rather
-    than guessed at)."""
+    anything that is neither (missing/malformed — stored as NULL rather than guessed
+    at).
+
+    IDEMPOTENT, and that is load-bearing: recheck_open_scopus() feeds the ALREADY-
+    hyphenated stored column value back through resolve_no_doi -> issn_in_pubmed ->
+    here. Normalizing only the 8-char form made that second pass fail the length test
+    and return None, so the ISSN pre-filter silently no-op'd for EVERY stored row —
+    the column shipped by #137/#138 could never once have changed a recheck decision.
+    Live-verified 2026-08-28 (issue #157): issn_in_pubmed('0890-9091') returned None
+    with no network call, while the raw '08909091' returned True."""
     issn = (issn or "").strip().upper()
+    if len(issn) == 9 and issn[4] == "-":
+        return issn
     return f"{issn[:4]}-{issn[4:]}" if len(issn) == 8 else None
 
 
@@ -217,7 +239,10 @@ def _extract_isbns(entry):
     holding ONE dict whose '$' is itself a bracketed comma-separated string —
     e.g. '[9781609136826, 9781469879918]' — not a real JSON array of separate
     values. Live-verified against a real Book doc, 2026-08-14; unpacked here
-    rather than trusted as-is."""
+    rather than trusted as-is.
+
+    _build_row stores the result comma-joined in authorship_review.isbn; recheck_open_
+    scopus splits it back on ',' — hence no comma inside an individual ISBN."""
     out = []
     for item in _as_list(entry.get("prism:isbn")):
         s = (item.get("$", "") if isinstance(item, dict) else str(item or "")).strip()
@@ -397,6 +422,10 @@ def _build_row(entry, i, n, author, top, cands, run_ts, dup_map=None):
         "title": entry.get("dc:title"),
         "journal": _trunc(entry.get("prism:publicationName"), 512),
         "issn": _normalize_issn(entry.get("prism:issn") or entry.get("prism:eIssn")),
+        # comma-joined (books carry several — print/ebook editions); NULL when absent.
+        # Book-like types are ISBN-keyed and carry no ISSN at all, so this is the only
+        # venue identifier they ever have — see recheck_open_scopus.
+        "isbn": _trunc(",".join(_extract_isbns(entry)), 128) or None,
         "doi": _trunc(doi, 255),
         "authors_json": _authors_json(entry),
         "classification": "absent",                    # no PMID -> production never scored it
@@ -428,19 +457,25 @@ def recheck_open_scopus(run_ts):
     curator's accept/reject is never clobbered. (No dedicated 'resolved' ENUM value;
     dismissed + an auto note is the removal-from-queue state.)
 
-    `issn` reaches the backlog two ways: rows upserted after the issn column shipped
-    already have it; older rows have issn=NULL until their next producer refresh
-    re-upserts them (source doc still has prism:issn) — until then resolve_no_doi
-    just falls through to the title check, same as before that column existed.
-    isbn isn't persisted at all (no column yet — unlike issn, ISBN only matters for
-    the small Book slice, not worth a migration until it's shown to matter at scale)
-    so Book rows in the backlog only get title-checked here, missing the ISBN-only
-    catches ingest-time resolution would find; deferred, matching the issn gap."""
+    `issn`/`isbn` reach the backlog two ways: rows upserted after each column shipped
+    already have it; older rows stay NULL until their next producer refresh re-upserts
+    them. The recurring cron only sweeps a recent ORIG-LOAD-DATE window, so rows from
+    the 2026-07-05 --mode initial five-year backfill are never revisited by it — they
+    need update/targeted_authors_backfill.py, which looks each document up by its
+    stored doi/external_id and fills the columns in place (see issue #157).
+
+    ISBN is passed for every pub_type, exactly as at ingest; resolve_no_doi still only
+    consults it for pub_type='Book'. Measured 2026-08-28 against the live open no-DOI
+    backlog, that narrowness is correct, not a leftover: 0 of 25 sampled Book Chapters
+    and 0 of 10 Editorials hit PubMed on ANY of their ISBNs (the ISBN is the parent
+    book's, and these books are simply not in NLM's catalog). Widening the branch to
+    Book Chapter — 505 of the 729 open no-DOI rows — would have added ~1,160 esearch
+    calls per weekly recheck for a measured zero catches."""
     from sqlalchemy import text
     eng = aar_db.engine()
     with eng.connect() as c:
         rows = c.execute(text(
-            "SELECT author_key, doi, title, wcm_author, pub_type, issn FROM authorship_review "
+            "SELECT author_key, doi, title, wcm_author, pub_type, issn, isbn FROM authorship_review "
             "WHERE source='scopus' AND status='open'")).mappings().all()
     resolved = 0
     for r in rows:
@@ -448,7 +483,8 @@ def recheck_open_scopus(run_ts):
             hit = doi_in_pubmed(r["doi"])
         else:
             author_last = (r["wcm_author"] or "").split()[-1] if r["wcm_author"] else None
-            hit = resolve_no_doi(r["title"], author_last, r["pub_type"], r["issn"])
+            hit = resolve_no_doi(r["title"], author_last, r["pub_type"], r["issn"],
+                                 (r["isbn"] or "").split(","))
         if hit:
             with eng.begin() as c:
                 c.execute(text(
@@ -633,6 +669,13 @@ def _selftest():
           issn_in_pubmed("bad") is None)
     check("_normalize_issn hyphenates Scopus's unhyphenated form",
           _normalize_issn("0732183X") == "0732-183X" and _normalize_issn("bad") is None)
+    # regression guard for #157: recheck_open_scopus feeds the STORED (already
+    # hyphenated) value back in. Re-normalizing used to return None, silently
+    # disabling the ISSN pre-filter for every row that had the column populated.
+    check("_normalize_issn is idempotent on the stored hyphenated form",
+          _normalize_issn("0890-9091") == "0890-9091"
+          and _normalize_issn(_normalize_issn("0732183X")) == "0732-183X"
+          and _normalize_issn("08909-091") is None)
     check("rolling window spans [today-90d, today-14d]",
           rolling_window(date(2026, 7, 4)) == ("20260405", "20260620"))
     check("rolling window honours custom lag/span",
@@ -685,6 +728,18 @@ def _selftest():
               {"given": "Jane", "surname": "Smith"}, {"given": "John", "surname": "Doe"}])
     check("row dup_flag=0/dup_reason=None with no dup_map (default)",
           row["dup_flag"] == 0 and row["dup_reason"] is None)
+    check("row isbn is None when the document carries no prism:isbn (an Article)",
+          row["isbn"] is None)
+
+    # a real Book entry: Scopus's bracketed-string-in-a-dict-in-a-list, stored
+    # comma-joined so recheck_open_scopus can split it straight back into a list
+    book = dict(entry, **{"subtypeDescription": "Book",
+                          "prism:isbn": [{"$": "[9781609136826, 9781469879918]"}]})
+    row_book = _build_row(book, i, n, au, top, [top], "2026-07-03 00:00:00")
+    check("row isbn stores the Scopus ISBN list comma-joined",
+          row_book["isbn"] == "9781609136826,9781469879918")
+    check("stored isbn splits back into exactly what _extract_isbns produced",
+          row_book["isbn"].split(",") == _extract_isbns(book))
 
     row_dup = _build_row(entry, i, n, au, top, [top], "2026-07-03 00:00:00",
                          dup_map={"10.1/x": ("abc1234", "SCOPUS:105037523511")})

--- a/update/targeted_authors_backfill.py
+++ b/update/targeted_authors_backfill.py
@@ -1,21 +1,29 @@
 #!/usr/bin/env python3
-"""Targeted per-document backfill for authorship_review.authors_json (reference tool).
+"""Targeted per-document backfill for authorship_review producer-owned columns
+(reference tool; the filename is historical -- authors_json was the first column it
+carried, and prior handoffs cite it by that name).
 
 WHAT IT DOES
-  For every still-NULL authorship_review row (source='scopus'), looks the document
-  up directly by its stored doi/external_id via a single-document Scopus Search API
-  query, then UPDATEs just the authors_json column on the matching row(s). There is
-  no discovery/matching step, no upsert, and no other column is touched -- we already
-  know exactly which documents we need.
+  For every authorship_review row (source='scopus') still NULL in any column of
+  COLUMNS below, looks the document up directly by its stored doi/external_id via a
+  single-document Scopus Search API query, then UPDATEs just those columns on the
+  matching row(s). There is no discovery/matching step, no upsert, and no column
+  outside COLUMNS is touched -- we already know exactly which documents we need.
 
-  Reuses aar_universe_scopus._scopus_get (same retry/backoff) and _authors_json (same
-  parser, already unit-tested) for byte-identical output to the real producer's field.
+  Every column is filled with COALESCE(existing, new), so a value the producer has
+  already written is never overwritten, and a re-run is safe.
+
+  Reuses aar_universe_scopus._scopus_get (same retry/backoff) and the producer's own
+  field extractors (_authors_json / _normalize_issn / _extract_isbns, all covered by
+  that module's selftest) so the backfilled values are byte-identical to what a
+  producer upsert of the same document would have written.
 
 WHEN TO USE THIS PATTERN
   A new derived column gets added to authorship_review and needs to be backfilled on
   documents that were already discovered and written by a prior run of
-  aar_universe_scopus.py. Copy-adapt this script for the new column rather than
-  generalizing this one -- it is a documented one-off pattern, not a framework.
+  aar_universe_scopus.py. Add it to COLUMNS -- the select/update/report all key off
+  that dict. Keep it to columns derivable from the single Scopus document already
+  being fetched; anything needing a different source deserves its own script.
 
 WHY `aar_universe_scopus.py --mode initial` CANNOT DO THIS
   The initial/rolling/recurring sweep is a discovery pass, not an idempotent column
@@ -36,6 +44,13 @@ RUNTIME REQUIREMENT
 PROVENANCE
   Run 2026-08-25 (authors_json column): 2,799 distinct documents considered,
   2,797 found via Scopus lookup (2 not_found), 4,155 rows updated, 0 errors.
+  issn/isbn (issue #157): NOT YET RUN. Sizing measured on prod 2026-08-28 --
+  7,902 scopus rows have issn NULL; of the 729 open no-DOI rows, a stratified
+  sample put "source doc actually has a prism:issn" at 19/20 Article, 6/8 Note,
+  5/12 Conference Paper, 4/4 Review and 0/6 Editorial, and "has a prism:isbn" at
+  15/15 for each of Book, Book Chapter and Editorial. Run it AFTER
+  setup/alter_authorship_review_add_isbn_v2.3.sql is applied to that instance --
+  without the column the isbn UPDATE errors out.
 
 Usage:
   python targeted_authors_backfill.py --limit 10   # dry-run sanity check first (default)
@@ -47,6 +62,14 @@ import aar_universe_scopus as scopus
 import aar_db
 from sqlalchemy import text
 
+# column -> how the producer derives it from a Scopus entry. Must stay byte-identical
+# to aar_universe_scopus._build_row; these are the same callables it uses.
+COLUMNS = {
+    "authors_json": scopus._authors_json,
+    "issn": lambda d: scopus._normalize_issn(d.get("prism:issn") or d.get("prism:eIssn")),
+    "isbn": lambda d: scopus._trunc(",".join(scopus._extract_isbns(d)), 128) or None,
+}
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -56,10 +79,14 @@ def main():
     dry_run = not args.apply
 
     engine = aar_db.engine()
+    # Documents needing at least one column. Rows whose document can never supply a
+    # column (a book has no ISSN) keep matching here and get re-fetched on every run;
+    # harmless for a manual one-off, and cheaper than a "already checked" marker column.
+    null_any = " OR ".join(f"{c} IS NULL" for c in COLUMNS)
     with engine.connect() as c:
         rows = c.execute(text(
             "SELECT DISTINCT doi, external_id FROM authorship_review "
-            "WHERE source='scopus' AND authors_json IS NULL"
+            f"WHERE source='scopus' AND ({null_any})"
         )).mappings().all()
 
     if args.limit:
@@ -84,23 +111,32 @@ def main():
                 time.sleep(0.5)
                 continue
             entry = entries[0]
-            authors_json = scopus._authors_json(entry)
+            vals = {col: fn(entry) for col, fn in COLUMNS.items()}
             found_docs += 1
             if dry_run:
-                print(f"  [{i}/{len(rows)}] OK (dry-run): {query} -> {authors_json[:100]}", flush=True)
+                shown = ", ".join(f"{k}={str(v)[:40]}" for k, v in vals.items())
+                print(f"  [{i}/{len(rows)}] OK (dry-run): {query} -> {shown}", flush=True)
             else:
-                with engine.begin() as c2:
-                    if doi:
-                        result = c2.execute(text(
-                            "UPDATE authorship_review SET authors_json=:aj "
-                            "WHERE source='scopus' AND doi=:doi AND authors_json IS NULL"),
-                            {"aj": authors_json, "doi": doi})
-                    else:
-                        result = c2.execute(text(
-                            "UPDATE authorship_review SET authors_json=:aj "
-                            "WHERE source='scopus' AND external_id=:eid AND authors_json IS NULL"),
-                            {"aj": authors_json, "eid": ext_id})
-                    updated_rows += result.rowcount
+                # Only touch columns this document can actually fill: a book carries no
+                # prism:issn, so its rows keep issn=NULL forever. Including such a column
+                # would make the UPDATE match those rows on every run and report them as
+                # updated when nothing changed (SQLAlchemy's MySQL dialect enables
+                # CLIENT_FOUND_ROWS, so rowcount counts MATCHED rows, not changed ones).
+                # COALESCE so a value the producer already wrote is never overwritten.
+                # guarded rather than `continue`d so the Scopus throttle at the
+                # bottom of the loop always runs (authors_json is never None, so
+                # today this is always true -- the guard is for the next column).
+                fillable = [c for c, v in vals.items() if v is not None]
+                if fillable:
+                    sets = ", ".join(f"{c}=COALESCE({c}, :{c})" for c in fillable)
+                    any_null = " OR ".join(f"{c} IS NULL" for c in fillable)
+                    key = "doi=:_key" if doi else "external_id=:_key"
+                    with engine.begin() as c2:
+                        result = c2.execute(
+                            text(f"UPDATE authorship_review SET {sets} "
+                                 f"WHERE source='scopus' AND {key} AND ({any_null})"),
+                            {**{c: vals[c] for c in fillable}, "_key": doi or ext_id})
+                        updated_rows += result.rowcount
         except Exception as e:
             errors += 1
             print(f"  [{i}/{len(rows)}] ERROR {query}: {e}", flush=True)


### PR DESCRIPTION
The headline of #157 was that authorship_review.issn is NULL for 92% of the open
no-DOI scopus backlog. Measuring it turned up a second, larger reason the pre-filter
never fires: _normalize_issn() only accepted the 8-char unhyphenated Scopus form, but
recheck_open_scopus() feeds back the ALREADY-hyphenated stored column value. That
second pass failed the length test and returned None, so issn_in_pubmed() bailed
before making a network call. The column shipped by #137/#138 could not once have
changed a recheck decision, on any row, NULL or not. _normalize_issn is now
idempotent, with a selftest guarding the round trip.

Persist isbn (migration v2.3, mirroring v2.1), so recheck_open_scopus can pass it to
resolve_no_doi exactly as the ingest path already does. Book-like documents are
ISBN-keyed and carry no prism:issn at all, so this is the only venue identifier they
ever have.

resolve_no_doi still consults ISBN only for pub_type='Book'. Measured against the
live backlog on 2026-08-28, that narrowness is right: 0 of 25 sampled Book Chapters
and 0 of 10 Editorials hit PubMed on any of their ISBNs. Widening it to Book Chapter
(505 of the 729 open no-DOI rows) would have cost ~1,160 extra esearch calls per
weekly recheck for zero measured catches.

Backfill for existing rows reuses update/targeted_authors_backfill.py, the repo's
documented per-document pattern, extended from one hardcoded column to a COLUMNS
dict covering authors_json/issn/isbn. That script exists precisely because the
--mode initial sweep cannot revisit these rows. Its UPDATE now COALESCEs, and only
touches columns the fetched document can actually supply, so a re-run reports 0
instead of re-matching book rows that have no ISSN to find.

No DDL has been applied. setup/alter_authorship_review_add_isbn_v2.3.sql must be run
by hand against the producer instance and the reciter-pm-dev instance, dev first.

## The finding that changes the issue's framing

#157 asks why the ISSN pre-filter cannot reach the no-DOI backlog and answers "92% of rows have `issn=NULL`". True, but not the binding constraint.

`_normalize_issn()` only accepted the 8-char unhyphenated Scopus form, while `recheck_open_scopus()` feeds back the already-hyphenated **stored** column value. The second pass fails the length test and returns `None`, so `issn_in_pubmed()` bails before making a network call:

```
raw Scopus value  '08909091'  -> _normalize_issn -> '0890-9091'
stored DB value   '0890-9091' -> _normalize_issn -> None
issn_in_pubmed(stored) = None   <- no network call, rejected on length
issn_in_pubmed(raw)    = True
```

So the column shipped by #137/#138 could never once have changed a recheck decision, on any row, NULL or not — and backfilling `issn` without this one-line fix would have been a provable no-op. Confirmed independently: all 21 distinct ISSNs on already-populated open no-DOI rows returned `None`, while a direct esearch on the same values translated cleanly (`0890-9091` → `"oncology williston park"[Journal]`, count 5627).

## Measurements (read-only against prod)

The issue's numbers reproduced exactly at session start: 10,505 total scopus / 6,380 open / 729 open no-DOI / 672 issn NULL / 365 auto-dismissed, with the pub_type breakdown row-for-row.

Fetching 95 real Scopus source docs (≤15 per pub_type) to measure rather than bound what a backfill would reach:

| pub_type | docs | w/ isbn | w/ issn |
|---|---:|---:|---:|
| Book Chapter | 15 | 15 | 0 |
| Editorial | 15 | 15 | 0 |
| Book | 15 | 15 | 0 |
| Conference Paper | 15 | 7 | 8 |
| Note | 13 | 3 | 10 |
| Article | 15 | 0 | 14 |
| Review/Letter/SS/Err | 7 | 0 | 7 |

Extrapolated: **~600 of the 729 rows (~82%) would gain an isbn** — more than the issue's 523/72%, because Editorial is ISBN-keyed too, which the issue did not catch. Conversely the issn backfill is *smaller* than the issue's "at most 149" ceiling: ~83 rows.

## Backfill uses existing machinery

`targeted_authors_backfill.py` already exists, and its docstring explains why `--mode initial` cannot do this job (the sweep drops any doc that resolves to PubMed *before* the upsert, so it never revisits an existing row). Extended from one hardcoded column to a `COLUMNS` dict rather than forked into a second near-identical script. Its UPDATE now COALESCEs and only touches columns the fetched document can supply — otherwise book rows re-match every run and `rowcount` over-reports, since SQLAlchemy's MySQL dialect enables `CLIENT_FOUND_ROWS`.

## Verification

- `python3 update/aar_universe_scopus.py --selftest` → 32 checks, SELFTEST PASS, including 4 new ones (idempotent normalize; isbn None on an Article; comma-joined ISBN list; round-trips back to what `_extract_isbns` produced).
- Migration validated by **applying it to a throwaway local MariaDB**, not by eyeballing the diff against v2.1.
- Adversarially reviewed on four lenses (correctness / regression / evidence / over-engineering) — all four PASS.

## Reviewer notes

1. `setup/alter_authorship_review_add_isbn_v2.3.sql` is **not applied** to any live database. Dev first, then prod.
2. The `_normalize_issn` idempotency fix is independently valuable and lands even if the isbn column is deferred.

Closes #157