### PR TITLE
fix(#159): temporal-plausibility penalty inside confidence, plus a queryable staleness column

### DIFF
--- a/setup/alter_authorship_review_add_top_years_after_wcm_v2.3.sql
+++ b/setup/alter_authorship_review_add_top_years_after_wcm_v2.3.sql
@@ -1,0 +1,134 @@
+-- =============================================================================
+-- Migration: authorship_review add top_years_after_wcm (v2.3)
+-- =============================================================================
+-- Adds:
+--   - top_years_after_wcm  INT  NULL  — paper publication year MINUS the top
+--                                       candidate's last WCM appointment year
+--                                       (identity.endDateWCMFaculty /
+--                                       endDateWCMStudent, whichever is later).
+--
+--     Signed and three-valued on purpose:
+--       NULL      unknown — the candidate has no WCM end year on file, or the
+--                 record carries no parseable publication year. NOT the same as 0.
+--       negative  the paper predates the departure. This is the LARGEST band
+--                 (11,661 of 19,273 open rows with a top candidate, measured
+--                 2026-08-28) and it is the legitimate case — exactly the missing
+--                 attributions this queue exists to find. It must stay
+--                 distinguishable from NULL and from 0.
+--       0..5      within the grace period: publication lag, late-career and
+--                 posthumous output, consortium reporting.
+--       6+        the stale band. 2,771 open rows on the same measurement, of
+--                 which 1,604 (58%) have a homonym cohort of exactly ONE person.
+--
+-- WHY THIS MIGRATION EXISTS:
+--   Issue #159: the matcher routinely proposes long-departed faculty as the top
+--   candidate for recent papers. The producer now applies a graduated, capped
+--   temporal penalty to `confidence` (update/identity_index.py temporal_penalty),
+--   but re-ranking can only ever help a row that HAS a rival to promote — and on
+--   58% of the stale rows the departed person is the only candidate in the cohort.
+--   There is nothing to re-rank. Persisting the gap as a queryable column is the
+--   lever that reaches those rows: Publication Manager can filter and sort the
+--   queue on the stale band and let curators bulk-dismiss it, which is issue #159's
+--   own "third, cheaper option".
+--
+--   No reader exists yet — the PM-side filter/sort is a separate issue in
+--   wcmc-its/ReCiter-Publication-Manager. This ships the producer half so the
+--   column is populated by the time that lands.
+--
+--   The fresh-build schema (setup/table_authorship_review.sql) is updated in the
+--   same PR. This migration brings EXISTING databases up to that schema. It must be
+--   applied directly to BOTH reciterdb instances — the producer instance and the
+--   separate dev instance behind reciter-pm-dev (loaded manually) — same as v1.6,
+--   v2.1 and v2.2. Merging the PR does NOT run DDL.
+--
+--   Apply with:
+--     mysql -h "$DB_HOST" -u "$DB_USERNAME" -p "$DB_NAME" \
+--       < setup/alter_authorship_review_add_top_years_after_wcm_v2.3.sql
+--
+-- DURABILITY: authorship_review is curator state, not a reporting export — not in
+--   update/updateReciterDB.py's truncate list, not touched by any nightly ETL step.
+--
+-- Additive only, guarded by an information_schema check (no-op on re-run).
+--
+-- THE BACKFILL BELOW IS NOT OPTIONAL. The producer only writes this column when it
+-- re-emits a row, and neither recheck path writes it at all: aar_orchestrator._recheck
+-- mutates only the CSV ledger, and aar_universe_scopus.recheck_open_scopus issues only
+-- `UPDATE … SET status='dismissed'`. Of the 2,771 existing stale open rows, 35 fall in
+-- the PubMed recurring window [today-71d, today-40d] and 69 in the Scopus rolling
+-- window [today-90d, today-14d] — about 1.3%. The other ~98% would keep NULL
+-- indefinitely, which would leave this column unable to do the one job it was added
+-- for. (Same lesson as update/targeted_authors_backfill.py: a sweep re-run cannot
+-- backfill a new column onto existing rows.)
+--
+-- The backfill uses YEAR(entrez_date) as the publication year, which the producer
+-- deliberately does NOT do — `entrez_date` is the NCBI index date on PubMed rows and a
+-- Scopus coverDate on Scopus rows. That substitution is acceptable HERE and nowhere
+-- else: on the Scopus lane it is exact (entrez_date IS coverDate,
+-- aar_universe_scopus.py:405), and on the PubMed lane, checked against
+-- analysis_summary_article.publicationDateStandardized for the 8,104 joinable open
+-- rows, it agrees exactly on 93.8%, differs by one year on 6.0% and by two or more on
+-- 0.16%. A one-year error cannot move a row across a band that is five years wide, and
+-- the producer overwrites the value with the true publication year on the row's next
+-- refresh anyway.
+--
+-- Measured on prod 2026-08-28, immediately before writing this file — open rows with a
+-- top candidate carrying a WCM end year:
+--   total backfilled            17,702
+--     paper predates departure  11,661   (negative — the legitimate case)
+--     0-5y   (grace)             3,270
+--     6-10y                      1,178
+--     11-20y                     1,149
+--     20y+                         444
+--   stale band (6y+)             2,771
+-- =============================================================================
+
+SET @db = DATABASE();
+
+-- -----------------------------------------------------------------------------
+-- top_years_after_wcm INT NULL — signed gap; negative = paper predates departure
+-- -----------------------------------------------------------------------------
+SET @sql = (SELECT IF(
+    (SELECT COUNT(*) FROM information_schema.columns
+     WHERE table_schema = @db AND table_name = 'authorship_review'
+       AND column_name = 'top_years_after_wcm') = 0,
+    'ALTER TABLE authorship_review ADD COLUMN `top_years_after_wcm` INT NULL',
+    'SELECT ''authorship_review.top_years_after_wcm already exists'''));
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+-- -----------------------------------------------------------------------------
+-- Verification
+-- -----------------------------------------------------------------------------
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = 'authorship_review'
+  AND column_name = 'top_years_after_wcm';
+
+-- -----------------------------------------------------------------------------
+-- Backfill existing rows. Idempotent: re-running recomputes the same values.
+--
+-- GREATEST over COALESCE(...,0) reproduces the producer's max(facultyEnd, studentEnd)
+-- reading, and the > 0 guard keeps rows with neither year at NULL rather than
+-- inventing a gap. The COLLATE casts on both sides of the cwid join are required —
+-- identity.cwid and authorship_review.top_cwid carry different collations and the join
+-- throws "Illegal mix of collations" without them.
+-- -----------------------------------------------------------------------------
+UPDATE authorship_review ar
+JOIN identity i
+  ON i.cwid COLLATE utf8mb4_general_ci = ar.top_cwid COLLATE utf8mb4_general_ci
+SET ar.top_years_after_wcm =
+      YEAR(ar.entrez_date) - GREATEST(COALESCE(i.endDateWCMFaculty, 0),
+                                      COALESCE(i.endDateWCMStudent, 0))
+WHERE ar.top_cwid IS NOT NULL
+  AND ar.entrez_date IS NOT NULL
+  AND GREATEST(COALESCE(i.endDateWCMFaculty, 0), COALESCE(i.endDateWCMStudent, 0)) > 0;
+
+-- Banded verification: compare against the counts in the header comment.
+SELECT COUNT(*)                                   AS backfilled,
+       SUM(top_years_after_wcm <  0)              AS before_departure,
+       SUM(top_years_after_wcm BETWEEN 0 AND 5)   AS grace_0_5,
+       SUM(top_years_after_wcm BETWEEN 6 AND 10)  AS stale_6_10,
+       SUM(top_years_after_wcm BETWEEN 11 AND 20) AS stale_11_20,
+       SUM(top_years_after_wcm >  20)             AS stale_20_plus
+FROM authorship_review
+WHERE status = 'open' AND top_years_after_wcm IS NOT NULL;

--- a/setup/table_authorship_review.sql
+++ b/setup/table_authorship_review.sql
@@ -67,6 +67,9 @@ CREATE TABLE IF NOT EXISTS `authorship_review` (
   `top_fg_score`           FLOAT        NULL,                -- production final (FG)
   `top_io_score`           FLOAT        NULL,                -- identity-only (IO)
   `top_confidence`         FLOAT        NULL,
+  `top_years_after_wcm`    INT          NULL,                -- paper year - top candidate's WCM end year;
+                                                             -- NEGATIVE = paper predates the departure,
+                                                             -- NULL = unknown (no end year / no pub year)
   `top_cohort_size`        INT          NULL,                -- homonyms (surname+initial)
   `top_given_match`        VARCHAR(16)  NULL,                -- full|initial
   `top_affil_match`        TINYINT(1)   NULL,

--- a/update/aar_db.py
+++ b/update/aar_db.py
@@ -32,7 +32,8 @@ _REFRESH_COLS = [
     "author_position", "author_position_label", "wcm_author", "author_affiliation",
     "entrez_date", "title", "journal", "issn", "doi", "authors_json", "classification",
     "top_cwid", "top_name", "top_person_type", "top_dept",
-    "top_fg_score", "top_io_score", "top_confidence", "top_cohort_size",
+    "top_fg_score", "top_io_score", "top_confidence", "top_years_after_wcm",
+    "top_cohort_size",
     "top_given_match", "top_affil_match", "n_candidates", "single_candidate",
     "candidate_cwids_json", "dup_flag", "dup_reason", "last_refreshed",
 ]
@@ -80,6 +81,7 @@ CREATE TABLE IF NOT EXISTS {TABLE} (
   top_fg_score           FLOAT        NULL,
   top_io_score           FLOAT        NULL,
   top_confidence         FLOAT        NULL,
+  top_years_after_wcm    INT          NULL,
   top_cohort_size        INT          NULL,
   top_given_match        VARCHAR(16)  NULL,
   top_affil_match        TINYINT(1)   NULL,

--- a/update/aar_matcher.py
+++ b/update/aar_matcher.py
@@ -23,11 +23,24 @@ Ranking key per candidate: (identity-only score desc, full>initial given match,
 confidence desc). The orchestrator (next step) calls `match_authorship()` for each
 WCM authorship on each orphan article and writes the ranked candidates to the ledger.
 
+Temporal plausibility (issue #159) reaches that key ONLY through `confidence`. A
+WCM-affiliated paper was written by someone who was at WCM when it was published, so a
+candidate proposed for a paper that appeared years after their appointment ended loses
+confidence points — a graduated, capped penalty (`identity_index.temporal_penalty`)
+that breaks ties but deliberately does NOT outrank the identity-only score or the
+given-name match, and never drops anyone. It needs the paper's year:
+`match_authorship(..., pub_year=None)` is exactly the pre-#159 ranking, so a caller
+that has no year loses nothing. The gap itself is published per row as
+`authorship_review.top_years_after_wcm`, which is the lever for the stale rows whose
+homonym cohort is one person and where re-ranking can do nothing.
+
 Confidence is an explainable ordering aid, NOT a probability:
     base   = 0.50 full given-name match | 0.25 initial-only
     rarity = 0.40 / cohort_size          (1 person -> 0.40, 2 -> 0.20, ...)
     affil  = +0.25 if the affiliation text names the candidate's dept/division
     hist   = -0.10 if the person is alumni / inactive / emeritus
+    stale  = -0.01 per year the paper postdates their WCM end year, after 5 grace
+             years, capped at -0.15 (reached at a 20-year gap)
     -> clipped to [0, 1]
 
 Env: DB_USERNAME/DB_PASSWORD/DB_HOST/DB_NAME (reciterdb, read-only). S3 + pinned
@@ -118,17 +131,23 @@ class IdentityOnlyScorer:
 
 
 # ---- public entry point ----------------------------------------------------
-def match_authorship(author, pmid, idx, io_scorer, top_k=5):
+def match_authorship(author, pmid, idx, io_scorer, top_k=5, pub_year=None):
     """Rank candidate CWIDs for one WCM authorship on an orphan article.
 
     author = {"last","fore","initials","affiliations"} (a universe author block).
-    Returns the ranked candidate list; each candidate gains:
+    pub_year = the paper's publication year (None -> no temporal penalty, pre-#159
+    ranking). Returns the ranked candidate list; each candidate gains:
       io_score  (float 0-100 | None)   ReCiter identity-only score for this pmid
       io_source ("retrieved" | "not_retrieved")
-    Ranking: identity-only score desc (nulls last) -> full given match -> confidence."""
+    Ranking: identity-only score desc (nulls last) -> full given match -> confidence.
+    The temporal penalty is inside `confidence` (issue #159) and is deliberately NOT a
+    term of its own: leading the key with it would let a one-year-past-grace gap
+    outrank a 50-point identity-only score, and would sink the penalised candidate out
+    of `candidates()`'s top_k altogether. So on this lane it moves the top pick only
+    among candidates otherwise tied — in practice the ones production never scored."""
     cands, cohort = idx.candidates(
         author.get("last"), author.get("fore"), author.get("initials"),
-        author.get("affiliations"), top_k=top_k)
+        author.get("affiliations"), top_k=top_k, pub_year=pub_year)
     for c in cands:
         v = io_scorer.scores(c["cwid"]).get(int(pmid)) if io_scorer else None
         c["io_score"] = round(v[0], 2) if v else None
@@ -148,14 +167,91 @@ def _print_candidates(cands, cohort_size):
         return
     for i, c in enumerate(cands, 1):
         io = f"{c['io_score']:.2f}" if c["io_score"] is not None else "  -  "
+        gap = c.get("years_after_wcm")
+        stale = f"stale={gap:+d}y" if gap is not None else ""
         print(f"  {i}. cwid={c['cwid']:10} io={io:>6} ({c['io_source']:13}) "
               f"conf={c['confidence']:.3f} {c['given_match']:7} "
-              f"affil={'Y' if c['affil_dept_match'] else '.'} "
+              f"affil={'Y' if c['affil_dept_match'] else '.'} {stale} "
               f"| {c['name']} — {c['person_type']}, {c['dept']}")
 
 
+def _rank_selftest():
+    """Offline (no DB, no S3): the temporal penalty rides inside `confidence` and must
+    stay BEHIND the identity-only score and the given-name match in this module's
+    re-sort (issue #159). Two Lees who both match "K Lee", plus the live Weiss row that
+    a penalty-leading sort key got wrong."""
+    def rec(given, surname, end_year, cwid):
+        return {"cwid": cwid, "given": given, "middle": "", "surname": surname,
+                "given_norm": _norm(given), "surname_norm": _norm(surname),
+                "dept": "", "division": "", "program": "", "title": "",
+                "person_type": "Inactive Faculty", "historical": True,
+                "end_year": end_year}
+
+    class _FakeIO:
+        """io_scorer stub: `scored` names the CWIDs production ever retrieved."""
+        def __init__(self, scored=("departed",)):
+            self.scored = scored
+
+        def scores(self, cwid):
+            return {99: (95.0, 0.0)} if cwid in self.scored else {}
+
+    idx = IdentityIndex([rec("Kevin", "Lee", 1999, "departed"),
+                         rec("Karen", "Lee", 2027, "here")])
+    author = {"last": "Lee", "fore": None, "initials": "K", "affiliations": []}
+    before = match_authorship(author, 99, idx, _FakeIO())                   # no pub_year
+    after = match_authorship(author, 99, idx, _FakeIO(), pub_year=2024)     # 25y stale
+    # nobody scored -> io ties at -1.0 and given_match ties, so confidence (carrying the
+    # penalty) is what decides. This is the `absent` classification, the common case.
+    tie = match_authorship(author, 99, idx, _FakeIO(scored=()), pub_year=2024)
+
+    # Blocker 2 regression. The shape is taken from live row 60896 / PMID 42430466
+    # ("Robert S Weiss"), where a penalty-leading key demoted weissro (io 50.61) below
+    # rww2001 (io 1.47) -- but the gap on that live row is 35 years (weissro's
+    # endDateWCMFaculty is 1991, the paper is 2026), NOT six. The six-year gap below is
+    # SYNTHETIC, chosen because a lexicographic lead term ignores magnitude: the
+    # smallest gap one year past the grace has to beat 49 points of identity evidence
+    # for the point to hold. Replaying the rejected key over 12,007 open rows, 23 flips
+    # did turn on a gap of exactly 6, but none of those demoted a candidate carrying a
+    # real io_score -- the smallest gap that demoted a SCORED candidate is 8 (row 34105,
+    # jjt2004, io 50.61). So do not read this as evidence that six-year gaps are
+    # dangerous in the live data, and do not tighten TEMPORAL_GRACE_YEARS on its basis.
+    weiss = IdentityIndex([rec("Robert", "Weiss", 2018, "weissro"),
+                           rec("Ronald", "Weiss", 2030, "rww2001")])
+
+    class _WeissIO:
+        def scores(self, cwid):
+            return {99: (50.61, 0.0) if cwid == "weissro" else (1.47, 0.0)}
+
+    wr = match_authorship({"last": "Weiss", "fore": None, "initials": "R",
+                           "affiliations": []}, 99, weiss, _WeissIO(), pub_year=2024)
+
+    checks = [
+        ("pre-#159 (no pub_year): io_score alone puts the departed Lee on top",
+         before[0]["cwid"] == "departed" and before[0]["io_score"] == 95.0),
+        ("INTENDED: a 25-year gap does NOT outrank a 95-point identity-only score",
+         after[0]["cwid"] == "departed"),
+        ("...the gap is still recorded for the curator-facing column",
+         after[0]["years_after_wcm"] == 25),
+        ("...and it costs confidence, capped so it never reaches 0.000",
+         0 < after[0]["confidence"] < before[0]["confidence"]),
+        ("with no identity-only score on either side the penalty breaks the tie",
+         tie[0]["cwid"] == "here" and tie[-1]["cwid"] == "departed"),
+        ("nothing is dropped: both Lees come back either way",
+         len(after) == 2 and len(tie) == 2),
+        ("a synthetic 6-year gap does not promote a 1.47 io_score over a 50.61 one "
+         "(shape of live row 60896, whose real gap is 35y)", wr[0]["cwid"] == "weissro"),
+    ]
+    ok = True
+    for label, passed in checks:
+        ok &= bool(passed)
+        print(f"  [{'OK' if passed else '** FAIL'}] {label}")
+    return ok
+
+
 def _selftest():
-    print("Loading identity index from reciterdb ...", flush=True)
+    print("=== Temporal-penalty ranking (offline) ===")
+    rank_ok = _rank_selftest()
+    print("\nLoading identity index from reciterdb ...", flush=True)
     idx = IdentityIndex.load()
     n = sum(len(v) for v in idx.by_surname.values())
     print(f"  indexed {n} identities across {len(idx.by_surname)} surnames")
@@ -187,7 +283,7 @@ def _selftest():
                       common_cohort)
 
     print("\n==== SELFTEST ====")
-    ok = True
+    ok = rank_ok
     for label, passed in checks:
         ok &= bool(passed)
         print(f"  [{'OK' if passed else '** FAIL'}] {label}")
@@ -203,6 +299,8 @@ def main():
     ap.add_argument("--initials")
     ap.add_argument("--affil", action="append", default=None)
     ap.add_argument("--pmid", type=int)
+    ap.add_argument("--pub-year", type=int, help="paper's publication year (enables the "
+                                                 "temporal-plausibility penalty)")
     ap.add_argument("--top-k", type=int, default=5)
     args = ap.parse_args()
 
@@ -216,11 +314,13 @@ def main():
     author = {"last": args.surname, "fore": args.given,
               "initials": args.initials, "affiliations": args.affil}
     if args.pmid:
-        cands = match_authorship(author, args.pmid, idx, io, top_k=args.top_k)
+        cands = match_authorship(author, args.pmid, idx, io, top_k=args.top_k,
+                                 pub_year=args.pub_year)
         cohort = idx.candidates(args.surname, args.given, args.initials, args.affil)[1]
     else:
         cands, cohort = idx.candidates(args.surname, args.given, args.initials,
-                                       args.affil, top_k=args.top_k)
+                                       args.affil, top_k=args.top_k,
+                                       pub_year=args.pub_year)
         for c in cands:
             c["io_score"], c["io_source"] = None, "(no --pmid)"
     print(f"=== {args.surname}, {args.given or args.initials or '?'} ===")

--- a/update/aar_orchestrator.py
+++ b/update/aar_orchestrator.py
@@ -142,7 +142,8 @@ def _position_label(i, n):
 def _compact(cands):
     """Trim candidate dicts for JSON storage in the ledger."""
     keep = ("cwid", "name", "person_type", "dept", "given_match", "affil_dept_match",
-            "cohort_size", "confidence", "io_score", "final_score", "io_source")
+            "cohort_size", "confidence", "years_after_wcm", "io_score", "final_score",
+            "io_source")
     return [{k: c.get(k) for k in keep} for c in cands]
 
 
@@ -187,7 +188,9 @@ def _db_rows(resolved_auth, run_date):
             "top_person_type": _trunc(top["person_type"], 64),
             "top_dept": _trunc(top["dept"], 255),
             "top_fg_score": fg, "top_io_score": top.get("io_score"),
-            "top_confidence": top["confidence"], "top_cohort_size": cohort,
+            "top_confidence": top["confidence"],
+            "top_years_after_wcm": top.get("years_after_wcm"),
+            "top_cohort_size": cohort,
             "top_given_match": top["given_match"],
             "top_affil_match": int(bool(top["affil_dept_match"])),
             "n_candidates": len(cands), "single_candidate": int(cohort == 1),
@@ -275,7 +278,8 @@ def run(date_from, date_to, state_dir, export_dir, run_date, workers=16, max_rec
             if not au.get("home_inst"):
                 continue
             cands, _ = idx.candidates(au.get("last"), au.get("fore"),
-                                      au.get("initials"), au.get("affiliations"), top_k=5)
+                                      au.get("initials"), au.get("affiliations"), top_k=5,
+                                      pub_year=a.get("pub_year"))
             cwid_pool.update(c["cwid"] for c in cands)
             authorships.append((a, i, n, au, cands))
     log(f"      {len(authorships)} WCM authorships; {len(cwid_pool)} distinct candidate CWIDs")
@@ -302,7 +306,8 @@ def run(date_from, date_to, state_dir, export_dir, run_date, workers=16, max_rec
     # top candidate per authorship, flag articles with ANY candidate final >= 30, drop them.
     resolved_auth, suggested_pmids = [], set()
     for a, i, n, au, _ in authorships:
-        cands = matcher.match_authorship(au, a["pmid"], idx, io, top_k=5)
+        cands = matcher.match_authorship(au, a["pmid"], idx, io, top_k=5,
+                                         pub_year=a.get("pub_year"))
         top = cands[0] if cands else None
         if top and top.get("final_score") is not None \
                 and top["final_score"] >= gate.STORAGE_THRESHOLD:

--- a/update/aar_universe.py
+++ b/update/aar_universe.py
@@ -11,8 +11,10 @@ What it does:
      and builds the same affiliation OR-query AffiliationRetrievalStrategy uses.
   2. ESearch (db=pubmed, datetype=edat, usehistory=y) over the entrez-date window.
   3. EFetch the records and parse: pmid, entrez date (PubStatus="entrez" history date,
-     identical to ArticleTranslator.java:329-351), title, journal, doi, authors+affils,
-     and which authors carry a home-institution affiliation.
+     identical to ArticleTranslator.java:329-351), publication year (the Journal
+     PubDate — a different thing from the entrez index date, and the one the matcher's
+     temporal-plausibility penalty compares against), title, journal, doi,
+     authors+affils, and which authors carry a home-institution affiliation.
   4. Filters to the precise parsed-entrez-date window and caches universe.json.
 
 Windows (entrez date):
@@ -22,6 +24,7 @@ Windows (entrez date):
 Env: PUBMED_API_KEY (read from environment, never logged), NCBI_EMAIL (optional).
 
 Usage:
+  python aar_universe.py --selftest                              # offline _pub_year checks
   python aar_universe.py --mode recurring
   python aar_universe.py --mode initial
   python aar_universe.py --from 2026/05/05 --to 2026/05/20 --out /tmp/u.json   # custom/test
@@ -151,6 +154,22 @@ def _entrez_date(article_el):
     return None
 
 
+def _pub_year(article_el):
+    """The paper's PUBLICATION year, for the matcher's temporal-plausibility penalty.
+
+    Deliberately not `_entrez_date`, which is the NCBI index date (and, on the Scopus
+    lane, a Scopus coverDate) — see issue #159. Journal PubDate/Year first, then the
+    leading year of a MedlineDate ('2019 Nov-Dec' -> 2019), then the electronic
+    ArticleDate. None when unparseable, which simply disables the penalty."""
+    pub = article_el.find("./MedlineCitation/Article/Journal/JournalIssue/PubDate")
+    if pub is not None:
+        for src in (pub.findtext("Year"), pub.findtext("MedlineDate")):
+            if src and src.strip()[:4].isdigit():
+                return int(src.strip()[:4])
+    y = article_el.findtext("./MedlineCitation/Article/ArticleDate/Year")
+    return int(y) if y and y.strip().isdigit() else None
+
+
 def _doi(article_el):
     for aid in article_el.findall("./PubmedData/ArticleIdList/ArticleId"):
         if aid.get("IdType") == "doi":
@@ -187,6 +206,7 @@ def parse_articles(xml_bytes, groups):
         out.append({
             "pmid": int(pmid),
             "entrez_date": _entrez_date(art),
+            "pub_year": _pub_year(art),
             "title": _text(art.find("./MedlineCitation/Article/ArticleTitle")),
             "journal": art.findtext("./MedlineCitation/Article/Journal/Title"),
             "doi": _doi(art),
@@ -241,8 +261,39 @@ def pull_universe(date_from, date_to, max_records=None, progress=True):
     }
 
 
+def _selftest():
+    """Offline (no network) checks for `_pub_year` — the publication-year parser the
+    temporal-plausibility penalty depends on (issue #159), on the larger of the two
+    lanes. Nothing else in this module asserted it."""
+    ok = True
+
+    def check(label, cond):
+        nonlocal ok
+        ok &= bool(cond)
+        print(f"  [{'OK' if cond else '** FAIL'}] {label}")
+
+    def art(pubdate, article_date=""):
+        return ET.fromstring(
+            "<PubmedArticle><MedlineCitation><Article><Journal><JournalIssue>"
+            f"{pubdate}</JournalIssue></Journal>{article_date}</Article>"
+            "</MedlineCitation></PubmedArticle>")
+
+    check("_pub_year reads Journal PubDate/Year",
+          _pub_year(art("<PubDate><Year>2024</Year><Month>Mar</Month></PubDate>")) == 2024)
+    check("_pub_year takes the leading year of a MedlineDate ('2019 Nov-Dec')",
+          _pub_year(art("<PubDate><MedlineDate>2019 Nov-Dec</MedlineDate></PubDate>")) == 2019)
+    check("_pub_year falls back to the electronic ArticleDate when PubDate has no year",
+          _pub_year(art("<PubDate/>", "<ArticleDate><Year>2021</Year></ArticleDate>")) == 2021)
+    check("_pub_year is None when the record carries no year at all "
+          "(absent case -> the penalty is simply off, pre-#159 ranking)",
+          _pub_year(art("<PubDate/>")) is None and _pub_year(art("")) is None)
+    print("SELFTEST", "PASS" if ok else "FAIL")
+    return ok
+
+
 def main():
     ap = argparse.ArgumentParser()
+    ap.add_argument("--selftest", action="store_true", help="offline _pub_year checks")
     ap.add_argument("--mode", choices=["initial", "recurring"])
     ap.add_argument("--from", dest="date_from", help="YYYY/MM/DD (custom window)")
     ap.add_argument("--to", dest="date_to", help="YYYY/MM/DD (custom window)")
@@ -250,6 +301,8 @@ def main():
     ap.add_argument("--out", default=None)
     args = ap.parse_args()
 
+    if args.selftest:
+        sys.exit(0 if _selftest() else 1)
     if args.mode:
         d_from, d_to = window_for_mode(args.mode)
         d_from, d_to = _fmt(d_from), _fmt(d_to)

--- a/update/aar_universe_scopus.py
+++ b/update/aar_universe_scopus.py
@@ -237,8 +237,17 @@ def _trunc(s, n):
 
 def _compact(cands):
     keep = ("cwid", "name", "person_type", "dept", "given_match", "affil_dept_match",
-            "cohort_size", "confidence")
+            "cohort_size", "confidence", "years_after_wcm")
     return [{k: c.get(k) for k in keep} for c in cands]
+
+
+def _pub_year(entry):
+    """Publication year from Scopus `prism:coverDate` ('2026-05-10'), for the matcher's
+    temporal-plausibility penalty (issue #159). This IS the paper's own date on this
+    lane — unlike the PubMed lane, where the stored `entrez_date` is the NCBI index
+    date and the publication year comes from the record's Journal PubDate instead."""
+    cover = entry.get("prism:coverDate") or ""
+    return int(cover[:4]) if cover[:4].isdigit() else None
 
 
 def _as_list(v):
@@ -406,6 +415,7 @@ def _build_row(entry, i, n, author, top, cands, run_ts, dup_map=None):
         "top_dept": _trunc(top["dept"], 255) if top else None,
         "top_fg_score": None, "top_io_score": None,    # scopus rail shows neither
         "top_confidence": top["confidence"] if top else None,
+        "top_years_after_wcm": top.get("years_after_wcm") if top else None,
         "top_cohort_size": cohort,
         "top_given_match": top["given_match"] if top else None,
         "top_affil_match": int(bool(top["affil_dept_match"])) if top else None,
@@ -511,7 +521,8 @@ def run(aft, bef, apply_writes=False, afid_list=DEFAULT_AFID_LIST, recheck=True,
     for d in scopus_only:
         for i, n, au, _ in wcm_authorships(d, family):
             cands, _ = idx.candidates(au["last"], au["fore"], au["initials"],
-                                      au["affiliations"], top_k=5)
+                                      au["affiliations"], top_k=5,
+                                      pub_year=_pub_year(d))
             top = cands[0] if cands else None
             if top is None:
                 unmatched += 1                         # nothing to assign (v1 skips unmatched)
@@ -694,6 +705,10 @@ def _selftest():
 
     check("_authors_json returns '[]' (not null) when the document has no author field",
           _authors_json({}) == "[]")
+
+    check("_pub_year reads the year off prism:coverDate, None when absent/malformed",
+          _pub_year(entry) == 2026 and _pub_year({}) is None
+          and _pub_year({"prism:coverDate": "n/a"}) is None)
 
     entry2 = dict(entry, **{"prism:doi": None})
     au2 = {"last": "Smith", "fore": "Jane", "initials": "J.", "affiliations": []}

--- a/update/identity_index.py
+++ b/update/identity_index.py
@@ -9,8 +9,10 @@ share. Extracted from `aar_matcher.py` so the Scopus lane can reuse the roster
 WITHOUT dragging in the matcher's S3 / pinned-model dependencies — which lets the
 detector run in-cluster (reciterdb CronJob) with only sqlalchemy + PyMySQL.
 
-Behaviour-preserving: the class, helpers, and person-type table are verbatim the
-ones `aar_matcher` used before the extraction.
+Also home to the TEMPORAL PLAUSIBILITY penalty (issue #159): a candidate whose WCM
+appointment ended long before the paper was published is almost always a homonym, so
+the gap between the two years subtracts from that candidate's `confidence`, and is
+published per row as `authorship_review.top_years_after_wcm`. See `temporal_penalty`.
 
 Env: DB_USERNAME/DB_PASSWORD/DB_HOST/DB_NAME (reciterdb, read-only).
 """
@@ -65,6 +67,70 @@ def _first_initial(fore, initials):
     return ""
 
 
+# ---- temporal plausibility -------------------------------------------------
+# A paper carrying a WCM affiliation was written by someone who WAS at WCM when it
+# was published, so a candidate whose appointment ended long before the paper is
+# almost always a homonym. The identity table's `endDateWCMFaculty` /
+# `endDateWCMStudent` are YEAR ints (2008, 2016 — NOT dates; YEAR() on them returns
+# NULL) and people who are still here carry a FUTURE end year (2027 typical, 2099
+# open-ended / emeritus), so a positive gap only ever arises for someone who has
+# actually left. Identities with neither year are never penalised.
+#
+# RANK DOWN, DO NOT SUPPRESS: this is a penalty term, never a filter. Most open review
+# rows whose top candidate has a past end year are papers published BEFORE that person
+# left — exactly the missing attributions this pipeline exists to find — and
+# late-career / posthumous / consortium output is real. A dropped row is also an
+# invisible failure; a low-ranked one stays auditable.
+#
+# IT REACHES RANKING ONLY THROUGH `confidence`, which keeps its existing LAST position
+# in both sort keys (here and in `aar_matcher.match_authorship`). It must never lead:
+# in a lexicographic key the lead term's MAGNITUDE is irrelevant, so a leading penalty
+# lets the smallest non-zero gap flip the top pick away from a full given-name +
+# affiliation match, and sinks the penalised candidate below every unpenalised cohort
+# member — past the top_k cut, which is suppression, not ranking down. The intended
+# consequence: staleness breaks ties, it cannot turn a strong match into a weak one.
+# On the Scopus lane (no identity-only score) it bites as a tiebreak after name and
+# affiliation; on the PubMed lane it mostly will not move `top_cwid`. That is why the
+# gap is ALSO published per row as `authorship_review.top_years_after_wcm` — a queryable
+# column reaches the stale rows whose cohort is one person, where re-ranking is a no-op.
+#
+# Rate and cap measured against the live queue on 2026-08-28 (47,673 candidate entries
+# on open rows, 11,279 of them past the grace, median gap 13y, widest 70y). The cap
+# exists because an uncapped 0.05/yr pinned 1,065 of 2,771 stale top candidates at
+# exactly 0.000, destroying the ordering the penalty exists to express. 0.01/yr puts the
+# cap at a 20-year gap — the boundary of issue #159's top band — so 76% of stale
+# candidates keep a graded penalty; beyond 20 years the exact gap lives in the
+# `top_years_after_wcm` column, not in confidence.
+#
+# The cap does NOT guarantee a non-zero confidence, and an earlier version of this
+# comment wrongly claimed it did. That claim came from `candidate_cwids_json`, which
+# stores only the top 5 per row; `_confidence` runs over EVERY cohort member here,
+# before the top_k cut. Replaying full cohorts, the smallest pre-penalty confidence is
+# 0.052, not 0.167, and 141 candidate entries still clamp to 0.000 — e.g. agk9007
+# (Agnes Kim, faculty end 2013) on open rows 24869/26720, where the author string
+# carries no given name so given_match is "unknown": base 0.15 + rarity 0.40/266 −
+# historical 0.10 = 0.052, and an 11-year gap costs 0.06. No operational effect today
+# (those 141 sit far below the top-5 cut on 2 rows), but do not raise the cap on the
+# assumption that a floor protects it.
+TEMPORAL_GRACE_YEARS = 5          # publication lag / late output after the last appointment year
+TEMPORAL_PENALTY_PER_YEAR = 0.01  # confidence points per stale year beyond the grace
+TEMPORAL_PENALTY_CAP = 0.15       # reached at a 20y gap (issue #159's top band boundary)
+
+
+def temporal_penalty(years_after_wcm):
+    """Graduated demotion for a candidate proposed long after they left WCM.
+
+    `years_after_wcm` = paper year - last WCM appointment year (None when either is
+    unknown, negative when the paper predates the departure). Zero through the grace
+    period, then TEMPORAL_PENALTY_PER_YEAR per further year, saturating at
+    TEMPORAL_PENALTY_CAP. THIS function returns the authoritative, already-capped
+    value — `_confidence` subtracts it once and nothing clamps it again."""
+    if not years_after_wcm or years_after_wcm <= TEMPORAL_GRACE_YEARS:
+        return 0.0
+    return round(min(TEMPORAL_PENALTY_PER_YEAR * (years_after_wcm - TEMPORAL_GRACE_YEARS),
+                     TEMPORAL_PENALTY_CAP), 3)
+
+
 # ---- identity index --------------------------------------------------------
 class IdentityIndex:
     """In-memory index of reciterdb `identity`, keyed by normalised surname."""
@@ -82,6 +148,7 @@ class IdentityIndex:
             connect_args={"connect_timeout": 15}, pool_pre_ping=True)
         cols = ("cwid, givenName, middleName, surname, primaryAcademicDepartment, "
                 "primaryAcademicDivision, primaryTitle, primaryProgram, "
+                "endDateWCMFaculty, endDateWCMStudent, "
                 + ", ".join(_PTYPE_COLS))
         with eng.connect() as c:
             rows = c.execute(text(
@@ -91,12 +158,18 @@ class IdentityIndex:
 
     @staticmethod
     def _record(r):
+        """One index record. `end_year` = the LATEST of the faculty/student WCM end
+        years (both YEAR ints; None when both are null). Taking the max is the
+        conservative reading — it penalises least — for the people who were here
+        twice (student then faculty); which of the two really means "left WCM" is
+        an open question on issue #159, so a reviewer can overrule this."""
         ptype, historical = "Other / CTSC", False
         for col, label, hist in PERSON_TYPES:
             if str(r[col]).lower() == "yes":
                 ptype, historical = label, hist
                 break
         given = r["givenName"] or ""
+        ends = [y for y in (r["endDateWCMFaculty"], r["endDateWCMStudent"]) if y]
         return {
             "cwid": r["cwid"],
             "given": given, "middle": r["middleName"] or "", "surname": r["surname"] or "",
@@ -106,10 +179,23 @@ class IdentityIndex:
             "program": r["primaryProgram"] or "",
             "title": r["primaryTitle"] or "",
             "person_type": ptype, "historical": historical,
+            "end_year": max(ends) if ends else None,
         }
 
-    def candidates(self, last, fore=None, initials=None, affiliations=None, top_k=5):
+    def candidates(self, last, fore=None, initials=None, affiliations=None, top_k=5,
+                   pub_year=None):
         """Ranked candidate CWIDs for one authorship (no identity-only score yet).
+
+        `pub_year` is the paper's publication year; pass it to enable the temporal
+        penalty (omitted -> `years_after_wcm` is None everywhere and ranking is exactly
+        as it was before issue #159). The penalty is folded into `confidence` and
+        reaches the sort key nowhere else, so it can only reorder candidates the name
+        and affiliation evidence leaves tied — it can never sink one below a rival the
+        evidence favours, and so can never push an evidence-favoured candidate past the
+        top_k cut. (In a cohort larger than top_k a stale candidate can still lose the
+        last slot to an evidence-EQUAL rival, exactly as any lower-confidence candidate
+        does. That is ranking; what issue #159 forbids is suppression regardless of
+        evidence, which a penalty at the FRONT of the key does and this does not.)
 
         Returns (candidates, cohort_size). cohort_size is the full homonym count
         (surname + initial) the curator faces, even if the list is capped at top_k."""
@@ -147,6 +233,8 @@ class IdentityIndex:
         out = []
         for rec, given_match in cohort:
             affil_match, where = self._affil_match(rec, affil_blob)
+            gap = (pub_year - rec["end_year"]) if (pub_year and rec["end_year"]) else None
+            penalty = temporal_penalty(gap)
             out.append({
                 "cwid": rec["cwid"],
                 "name": " ".join(x for x in (rec["given"], rec["middle"], rec["surname"]) if x),
@@ -155,8 +243,9 @@ class IdentityIndex:
                 "given_match": given_match,
                 "affil_dept_match": affil_match, "affil_match_on": where,
                 "cohort_size": cohort_size,
+                "years_after_wcm": gap,
                 "confidence": self._confidence(given_match, cohort_size, affil_match,
-                                               rec["historical"]),
+                                               rec["historical"], penalty),
             })
         out.sort(key=lambda d: (d["given_match"] == "full", d["affil_dept_match"],
                                 d["confidence"]), reverse=True)
@@ -178,25 +267,31 @@ class IdentityIndex:
         return False, None
 
     @staticmethod
-    def _confidence(given_match, cohort_size, affil_match, historical):
+    def _confidence(given_match, cohort_size, affil_match, historical, penalty=0.0):
+        """Explainable ordering aid, NOT a probability. `historical` is the flat
+        person-type flag (alumni/inactive/emeritus); `penalty` is the already-capped
+        temporal term from `temporal_penalty`, applied exactly once and ONLY here —
+        this is the single route by which staleness reaches either sort key."""
         base = 0.50 if given_match == "full" else 0.25 if given_match == "initial" else 0.15
         rarity = 0.40 / max(cohort_size, 1)
         affil = 0.25 if affil_match else 0.0
         hist = -0.10 if historical else 0.0
-        return round(max(0.0, min(1.0, base + rarity + affil + hist)), 3)
+        return round(max(0.0, min(1.0, base + rarity + affil + hist - penalty)), 3)
 
 
 # ---- offline self-test ------------------------------------------------------
 def _selftest():
     """Builds an IdentityIndex from hand-built records (no DB) to prove the
-    middleName-as-alternate-given-name fix (Judy/Hua Zhong, PMID 40681448)."""
-    def rec(given, middle, surname):
+    middleName-as-alternate-given-name fix (Judy/Hua Zhong, PMID 40681448) and the
+    temporal-plausibility penalty (issue #159)."""
+    def rec(given, middle, surname, end_year=None, cwid=None):
         return {
-            "cwid": f"{given or middle}_{surname}".lower(),
+            "cwid": cwid or f"{given or middle}_{surname}".lower(),
             "given": given, "middle": middle, "surname": surname,
             "given_norm": _norm(given), "surname_norm": _norm(surname),
             "dept": "", "division": "", "program": "", "title": "",
             "person_type": "Full-Time Faculty", "historical": False,
+            "end_year": end_year,
         }
 
     records = [
@@ -219,6 +314,107 @@ def _selftest():
                     "xiu_zhong" not in by_cwid))
     checks.append(("cohort_size counts only the two initial-matching records",
                     cohort_size == 2))
+
+    # --- temporal plausibility (issue #159) ---------------------------------
+    # Three Smiths who all match "J Smith" equally on name; only the WCM end year
+    # differs. Paper published 2024.
+    smiths = IdentityIndex([
+        rec("John", "", "Smith", end_year=2027, cwid="here"),      # still here
+        rec("James", "", "Smith", end_year=2021, cwid="recent"),   # left 3y ago
+        rec("Jane", "", "Smith", end_year=2001, cwid="departed"),  # left 23y ago
+    ])
+    ranked, _ = smiths.candidates("Smith", None, "J", pub_year=2024)
+    order = [c["cwid"] for c in ranked]
+    by = {c["cwid"]: c for c in ranked}
+    checks += [
+        ("2024 paper: 23-years-departed Smith ranks last (name evidence ties, the "
+         "penalty breaks it)", order[-1] == "departed"),
+        ("recent leaver (3y < grace) is NOT penalised",
+         by["recent"]["confidence"] == by["here"]["confidence"]),
+        ("penalty is visible in the curator-facing confidence",
+         by["departed"]["confidence"] < by["here"]["confidence"]),
+        ("nobody is dropped: all three still returned", len(ranked) == 3),
+        ("the signed gap rides along for authorship_review.top_years_after_wcm "
+         "(negative = the paper predates the departure, distinct from NULL)",
+         by["departed"]["years_after_wcm"] == 23 and by["here"]["years_after_wcm"] == -3),
+    ]
+
+    # REGRESSION (issue #159 rework, blocker 1 — SUPPRESSION). Cohort of 7 against
+    # top_k=5, where the stale candidate is the one the evidence actually favours: full
+    # given name plus an affiliation-department match, against six initial-only
+    # homonyms. A penalty at the FRONT of the sort key sinks him below all six and the
+    # top_k cut then deletes him from the list outright — he never reaches cwid_pool,
+    # never reaches candidate_cwids_json, and the curator cannot select him. He must
+    # come back FIRST.
+    crowd = IdentityIndex(
+        [dict(rec("Robert", "", "Weiss", end_year=2003, cwid="true_author"),
+              dept="Pathology")]
+        + [rec(g, "", "Weiss", end_year=2030, cwid=f"homonym{i}")
+           for i, g in enumerate(("Rita", "Ramona", "Rachel", "Rebecca", "Rhonda", "Rose"))])
+    crowded, crowd_size = crowd.candidates(
+        "Weiss", "Robert", "R", ["Department of Pathology, Weill Cornell Medicine"],
+        pub_year=2024, top_k=5)
+    checks += [
+        ("cohort (7) is larger than top_k (5), so the cut is real",
+         crowd_size == 7 and len(crowded) == 5),
+        ("21-years-stale candidate with full given name + affiliation match survives "
+         "the top_k cut and still ranks first (rank down != suppress)",
+         crowded[0]["cwid"] == "true_author"),
+    ]
+
+    # REGRESSION (blocker 2 — EPSILON OUTRANKS EVIDENCE). In a lexicographic key the
+    # lead term's magnitude is irrelevant, so a leading penalty lets the smallest
+    # non-zero gap (6 years, one past the grace) flip the top pick away from a full
+    # given-name + affiliation match to an initial-only homonym.
+    eps = IdentityIndex([
+        dict(rec("Robert", "", "Weiss", end_year=2018, cwid="true_author"),
+             dept="Pathology"),
+        rec("Rita", "", "Weiss", end_year=2030, cwid="homonym"),
+    ])
+    eps_ranked, _ = eps.candidates(
+        "Weiss", "Robert", "R", ["Department of Pathology, Weill Cornell Medicine"],
+        pub_year=2024)
+    checks += [
+        ("6-year gap does not flip the top pick away from a full given-name + "
+         "affiliation match", eps_ranked[0]["cwid"] == "true_author"),
+        ("...and that epsilon penalty is genuinely non-zero", temporal_penalty(6) == 0.01),
+    ]
+
+    # A paper published BEFORE they left must not be penalised at all (the largest
+    # measured band is exactly this case).
+    early, _ = smiths.candidates("Smith", None, "J", pub_year=1998)
+    # No pub_year supplied -> pre-#159 behaviour, bit for bit.
+    noyear, _ = smiths.candidates("Smith", None, "J")
+    checks += [
+        ("paper predating the departure: nobody penalised, ranking and confidences "
+         "identical to the no-pub_year run",
+         [c["cwid"] for c in early] == [c["cwid"] for c in noyear]
+         and [c["confidence"] for c in early] == [c["confidence"] for c in noyear]),
+        ("no pub_year -> pre-#159 behaviour: no gap recorded anywhere",
+         all(c["years_after_wcm"] is None for c in noyear)),
+    ]
+
+    # CAP. Widest gap in the live open queue is 70 years; uncapped 0.05/yr pinned 1,065
+    # of 2,771 stale top candidates at confidence 0.000, which is why the cap exists.
+    # The cap is NOT a guarantee of non-zero confidence — see the deep-cohort case
+    # below, which is asserted rather than left to prose so nobody re-derives the
+    # "there is a floor" mistake from an earlier draft of this file.
+    widest, _ = IdentityIndex(
+        [rec("Jane", "", "Smith", end_year=1954, cwid="ancient")]).candidates(
+            "Smith", None, "J", pub_year=2024)
+    checks += [
+        ("penalty saturates: a 20y gap and the widest real 70y gap cost the same 0.15",
+         temporal_penalty(20) == temporal_penalty(70) == TEMPORAL_PENALTY_CAP == 0.15),
+        ("a deep-cohort historical candidate CAN still clamp to 0.000: the cap is not "
+         "a floor (agk9007-shaped — 'Kim', cohort 266, no given name, 11y gap)",
+         IdentityIndex._confidence("unknown", 266, False, True,
+                                   temporal_penalty(11)) == 0.0),
+        ("widest real gap (70y) does not pin confidence at 0.000",
+         widest[0]["years_after_wcm"] == 70 and widest[0]["confidence"] > 0.0),
+        ("temporal_penalty: 0 through the grace, then monotone up to the cap",
+         [temporal_penalty(g) for g in (None, -20, 0, 5, 6, 10, 20, 70)]
+         == [0.0, 0.0, 0.0, 0.0, 0.01, 0.05, 0.15, 0.15]),
+    ]
 
     ok = True
     for desc, passed in checks:


### PR DESCRIPTION
The AAR matcher routinely proposes long-departed faculty as the top candidate for
recently published papers. A paper carrying a WCM affiliation was written by someone
who was at WCM at publication time, so a match to someone who left two decades earlier
is a homonym false match. Compare the paper's publication year against the candidate's
last WCM appointment year (identity.endDateWCMFaculty / endDateWCMStudent, both YEAR
ints, latest non-null of the two) and act on the gap two ways.

1. RANKING. identity_index.temporal_penalty() subtracts from confidence: zero through
   a 5-year grace for publication lag, then 0.01 per further year, saturating at 0.15
   (reached at a 20-year gap). It is applied exactly once, in _confidence, and reaches
   ranking nowhere else. Both sort keys keep their evidence order — candidates() is
   (full given match, affil match, confidence), match_authorship() is (io_score, full
   given match, confidence) — so staleness breaks ties but never outranks io_score, the
   given-name match or the affiliation match.

   The penalty deliberately does NOT lead either key. In a lexicographic tuple the lead
   term's magnitude is irrelevant, so a leading penalty (a) let an epsilon gap one year
   past the grace flip the top pick away from a full given-name plus affiliation match,
   and (b) sank penalised candidates below every unpenalised cohort member, past the
   top_k cut, deleting them from cwid_pool and candidate_cwids_json entirely —
   suppression, which the issue forbids.

   On (a), be precise about what the data does and does not show. Replaying the rejected
   key over 12,007 open rows, 23 flips turn on a gap of exactly 6, but none of those
   demoted a candidate carrying a real io_score; the smallest gap that demoted a SCORED
   candidate is 8 (row 34105, jjt2004, io 50.61). The six-year case in the self-tests is
   therefore SYNTHETIC — it exists because a lead term ignores magnitude, so the
   smallest possible penalty has to be the one tested. Live row 60896 / PMID 42430466
   supplies the shape of that test, but its real gap is 35 years (weissro's
   endDateWCMFaculty is 1991, the paper is 2026), not six. Do not read the six-year
   figure as live evidence and do not tighten the grace period on its basis.

   Replayed read-only against prod over the 12,007 open rows that reconstruct exactly:
   of the 22 whose stale top candidate sits in a cohort larger than top_k, a
   penalty-leading key loses that candidate from the returned list in 20 and this one
   in 0. It drops nobody the evidence favoured: all 353 top-5 membership changes are
   evidence-equal confidence tiebreaks, against 83 evidence-dominated drops for the
   leading variant. 215 rows (1.79%) change top_cwid at the candidates() level, 165 of
   them PubMed rows that then face the identity-only re-sort, where 154 are classified
   'absent' (production never scored the old top, so io ties and confidence still
   decides) and 11 carry a real io_score that leads the key.

   Rate and cap are measured, not chosen by taste. Over 47,673 candidate entries on
   open rows (11,279 past the grace, median gap 13y, widest 70y), uncapped 0.05/year
   pinned 642 of the 12,007 replayed top candidates at exactly 0.000 and left FEWER
   distinct confidence values (112) than the capped version (146) — it destroyed the
   ordering it was meant to express. 0.01 per year puts the cap at a 20-year gap, the
   top band boundary, leaving 76% of stale candidates with a graded value.

   The cap is not a floor. An earlier draft claimed a 0.15 cap could never pin
   confidence at 0.000 because the smallest observed pre-penalty confidence was 0.167;
   that number came from candidate_cwids_json, which stores only the top 5 per row,
   while _confidence runs over every cohort member before the top_k cut. Over full
   cohorts the real minimum is 0.052 and 141 candidate entries still clamp to zero —
   e.g. agk9007 (Agnes Kim, faculty end 2013) on open rows 24869/26720, where the
   author string has no given name: 0.15 base + 0.40/266 rarity − 0.10 historical =
   0.052 against an 11-year gap's 0.06. No operational effect (those 141 sit far below
   the top-5 cut on 2 rows), and it is now asserted in the self-test rather than
   claimed in a comment.

2. REPORTING. New nullable, signed authorship_review.top_years_after_wcm, with
   migration setup/alter_authorship_review_add_top_years_after_wcm_v2.3.sql. Negative
   means the paper predates the departure — the legitimate case and the largest band
   (58.9% of replayed rows) — and stays distinguishable from NULL (unknown) and 0.
   This is the lever re-ranking cannot be: 1,604 of the 2,771 stale open rows (58%)
   have a homonym cohort of exactly one person, so there is nothing to re-rank. Like
   v2.1 and v2.2 the migration must be applied by hand to both reciterdb instances;
   merging this does not run DDL. No reader exists yet — the PM filter/sort on the
   stale band is a separate issue in ReCiter-Publication-Manager.

   The migration carries a BACKFILL, and it is not optional. The producer writes this
   column only when it re-emits a row, and neither recheck path writes it at all:
   aar_orchestrator._recheck mutates only the CSV ledger, and recheck_open_scopus
   issues only UPDATE … SET status='dismissed'. Of the 2,771 existing stale open rows,
   35 fall in the PubMed recurring window and 69 in the Scopus rolling window — about
   1.3%; the rest would keep NULL indefinitely, leaving the column unable to do the one
   job it was added for. The backfill derives the year from YEAR(entrez_date), which
   the producer deliberately does not do; that substitution is acceptable only here,
   because on the Scopus lane it is exact (entrez_date IS coverDate) and on the PubMed
   lane it agrees with analysis_summary_article.publicationDateStandardized on 93.8% of
   the 8,104 joinable open rows, differing by one year on 6.0% and by two or more on
   0.16% — and a one-year error cannot move a row across a five-year band. It backfills
   17,702 open rows: 11,661 negative, 3,270 in grace, 1,178 at 6-10y, 1,149 at 11-20y,
   444 beyond 20y.

The publication year in the PRODUCER comes from the source record, never from the
overloaded entrez_date column: PubMed's Journal PubDate (new aar_universe._pub_year,
falling back to a MedlineDate's leading year and then to ArticleDate) and Scopus's
prism:coverDate. pub_year is optional everywhere; with no year the penalty is off and
the ranking is bit-for-bit the pre-#159 one.

Self-tests stay offline and in the established in-file style. identity_index gains the
two regressions that catch the rejected design — a cohort larger than top_k where the
stale candidate is the one the evidence favours, and an epsilon gap against a full
given-name plus affiliation match — plus the cap, the deep-cohort clamp, and the
no-pub_year case. Both regressions were confirmed to FAIL against the rejected commit
09ec29c before being kept. aar_matcher asserts the penalty stays behind io_score.
aar_universe gains its first _selftest, covering _pub_year over <Year>, MedlineDate
("2019 Nov-Dec") and the absent case.

## Design note: this is deliberately NOT the issue's literal proposal

#159 proposes promoting the temporal term above `confidence` in the sort key. A first implementation went further and made it the **lead** term at both sort sites. Four independent adversarial verifiers rejected it, on two blockers that are worth recording because they constrain any future change here:

1. **A leading penalty suppresses instead of ranking down.** In `candidates()` the sort runs immediately before `return out[:top_k]`, so any penalised candidate sinks below every unpenalised cohort member and falls past the top-5 cut. Measured: of 279 open rows with a stale top candidate and cohort > 5, replaying the 170 reconstructible ones, **126 lost the candidate outright**. The cwid then never enters `cwid_pool`, never reaches `candidate_cwids_json` so a curator cannot select it, and `_recheck` can no longer auto-resolve the row. That is exactly what the issue forbids.
2. **In a lexicographic tuple the lead term's magnitude is irrelevant**, so the smallest possible penalty overrode full-name and affiliation evidence. On a live row it demoted a candidate with `io=50.61` below one with `io=1.47` — worse than the bug being fixed.

And a hard ceiling on the whole approach: **1,604 of the 2,771 stale open rows (58%) have a homonym cohort of exactly one.** The departed person is the only candidate. Re-ranking is a no-op on the majority of the rows this issue is about, which is why the queryable column — not the penalty — is the load-bearing half of this PR.

Both regressions were confirmed to FAIL against the rejected commit `09ec29c` before being kept, rather than merely asserted to.

## Verification

All four in-file harnesses pass, offline, in the established style:

```
python3 update/identity_index.py        -> SELFTEST PASS (19 checks)
python3 update/aar_matcher.py --selftest -> SELFTEST PASS (7 offline + live DB/S3/model)
python3 update/aar_universe.py --selftest -> SELFTEST PASS (4 checks; file had none before)
python3 update/aar_universe_scopus.py --selftest -> SELFTEST PASS (29 checks)
```

Reviewed adversarially on three lenses. Blockers and regression PASS. The evidence lens caught three false statements about live data — a six-year gap wrongly attributed to a live row whose real gap is 35 years, a "0.167 confidence floor" measured on the top-5-truncated `candidate_cwids_json` when the true full-cohort minimum is 0.052, and a migration claiming the recheck path would populate the column when it writes no DB column at all. All three are corrected in the commit above, and the third is why the migration now carries a backfill. Every other number in the commit was independently reproduced from scratch by the verifier's own replay and SQL.

## Reviewer notes

1. **The migration is not applied.** `setup/alter_authorship_review_add_top_years_after_wcm_v2.3.sql` must be run by hand against both reciterdb instances, and it now includes the backfill UPDATE plus a banded verification SELECT. Without the backfill the column reaches ~1.3% of the rows it exists for.
2. **The cap is not a floor** — a deep-cohort historical candidate can still clamp to 0.000. Asserted in the self-test so the limitation cannot be re-derived away.
3. **`max(endDateWCMFaculty, endDateWCMStudent)`** is the conservative reading of "left WCM" (it penalises least) for people who were here twice. The issue explicitly leaves this open; overrule if you disagree.
4. **No PM reader exists yet.** The filter/sort on the stale band is a separate issue in ReCiter-Publication-Manager, worth filing once this lands.
5. Composes with #161 and #162: test-merged all three, 0 conflicts, all self-checks pass in the combined tree.

Closes #159