### PR TITLE
chore: rename the top_years_after_wcm migration v2.3 -> v2.5 (duplicate version number)

### DIFF
--- a/setup/alter_authorship_review_add_top_years_after_wcm_v2.5.sql
+++ b/setup/alter_authorship_review_add_top_years_after_wcm_v2.5.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- Migration: authorship_review add top_years_after_wcm (v2.3)
+-- Migration: authorship_review add top_years_after_wcm (v2.5)
 -- =============================================================================
 -- Adds:
 --   - top_years_after_wcm  INT  NULL  — paper publication year MINUS the top
@@ -43,7 +43,7 @@
 --
 --   Apply with:
 --     mysql -h "$DB_HOST" -u "$DB_USERNAME" -p "$DB_NAME" \
---       < setup/alter_authorship_review_add_top_years_after_wcm_v2.3.sql
+--       < setup/alter_authorship_review_add_top_years_after_wcm_v2.5.sql
 --
 -- DURABILITY: authorship_review is curator state, not a reporting export — not in
 --   update/updateReciterDB.py's truncate list, not touched by any nightly ETL step.


### PR DESCRIPTION
#162 and #163 both shipped a migration numbered v2.3, because they were built on parallel branches:

- `setup/alter_authorship_review_add_isbn_v2.3.sql` (#157)
- `setup/alter_authorship_review_add_top_years_after_wcm_v2.3.sql` (#159)

These migrations are applied by hand, in order, against two separate reciterdb instances. A duplicate version number is a live risk of applying one and believing both are done. `v2.4` is taken by `fix_authorship_review_dup_flag_v2.4.sql`, so the top_years migration becomes `v2.5`.

Rename plus the two in-file self-references. No SQL change, and neither file has been applied to any instance yet.