### PR TITLE
fix: keep identity.cwid indexable in the top_years_after_wcm backfill

### DIFF
--- a/setup/alter_authorship_review_add_top_years_after_wcm_v2.5.sql
+++ b/setup/alter_authorship_review_add_top_years_after_wcm_v2.5.sql
@@ -109,13 +109,19 @@ WHERE table_schema = DATABASE()
 --
 -- GREATEST over COALESCE(...,0) reproduces the producer's max(facultyEnd, studentEnd)
 -- reading, and the > 0 guard keeps rows with neither year at NULL rather than
--- inventing a gap. The COLLATE casts on both sides of the cwid join are required —
--- identity.cwid and authorship_review.top_cwid carry different collations and the join
--- throws "Illegal mix of collations" without them.
+-- inventing a gap.
+--
+-- A COLLATE cast is required — identity.cwid is utf8mb4_unicode_ci and
+-- authorship_review.top_cwid is utf8mb4_general_ci, so the join throws "Illegal mix of
+-- collations" without one. Cast ONLY the authorship_review side, to identity's
+-- collation. Casting both sides makes identity.cwid's index unusable and the join
+-- degenerates to a full index scan per row: EXPLAIN went from 26,884 estimated row
+-- combinations to 880,934,912, and a dev run sat in "Sending data" for 5+ minutes with
+-- nothing committed. Leaving i.cwid bare keeps the plan at type=ref, rows=1.
 -- -----------------------------------------------------------------------------
 UPDATE authorship_review ar
 JOIN identity i
-  ON i.cwid COLLATE utf8mb4_general_ci = ar.top_cwid COLLATE utf8mb4_general_ci
+  ON i.cwid = ar.top_cwid COLLATE utf8mb4_unicode_ci
 SET ar.top_years_after_wcm =
       YEAR(ar.entrez_date) - GREATEST(COALESCE(i.endDateWCMFaculty, 0),
                                       COALESCE(i.endDateWCMStudent, 0))


### PR DESCRIPTION
The backfill in `setup/alter_authorship_review_add_top_years_after_wcm_v2.5.sql` cast **both** sides of the cwid join to `utf8mb4_general_ci`:

```sql
ON i.cwid COLLATE utf8mb4_general_ci = ar.top_cwid COLLATE utf8mb4_general_ci
```

`identity.cwid` is `utf8mb4_unicode_ci`. Casting it away from its own collation makes its index unusable, so the join does a full index scan of `identity` for every `authorship_review` row.

Measured on prod with EXPLAIN:

| | driving table | identity | est. row combinations |
|---|---|---|---|
| both sides cast | ALL, 26,884 | **type=index**, 32,768 | **880,934,912** |
| cast ar side only | ALL, 26,884 | **type=ref**, 1 | **26,884** |

Caught live: a dev run of this statement sat in `Sending data` for over five minutes with nothing committed.

The fix casts only the `authorship_review` side, to identity's collation. That resolves the mismatch just as well and leaves `i.cwid` indexable. Identical values written either way — this is purely the access path.

Worth noting the repo already had this lesson written down ("a NOT EXISTS with a collation cast goes O(n²) and will not finish"); the trap is specifically casting the *indexed* side.