### PR TITLE
fix: ship targeted_authors_backfill.py in the reciterdb image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,14 @@ COPY update/preprocessing.py ./
 COPY update/aar_models/ ./aar_models/
 COPY update/aar_data/ ./aar_data/
 
+# Manual reference tool: per-document backfill of producer-owned authorship_review
+# columns (authors_json / issn / isbn) on rows a sweep can no longer revisit. Not run by
+# run_all.py -- invoked by hand as a one-off Job off this image. Its own docstring says it
+# "must run inside the reciterdb container", which was not true until it was shipped here:
+# it sys.path.insert("/usr/src/app") and imports aar_universe_scopus + aar_db, both of
+# which are already in the image above.
+COPY update/targeted_authors_backfill.py ./
+
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 # Or, if not using requirements.txt:


### PR DESCRIPTION
`update/targeted_authors_backfill.py` documents itself as:

> RUNTIME REQUIREMENT — Must run inside the reciterdb container -- it imports update/aar_universe_scopus.py and update/aar_db.py via sys.path.insert(0, "/usr/src/app"), the container's app root, and needs the container's Scopus API credentials and DB connection.

That is not currently possible. The Dockerfile has no `COPY` line for it, so the file is absent from every built image and a Job off that image cannot invoke it.

Everything it imports is already in the image (`aar_universe_scopus.py`, `aar_db.py`, and `identity_index.py` behind them), and the Dockerfile copies scripts flat into `/usr/src/app`, so its `sys.path.insert(0, "/usr/src/app")` resolves correctly once the file is there. One line.

Needed now to run the `issn`/`isbn` backfill for #157 against the rows the rolling ORIG-LOAD-DATE sweep can no longer revisit — the columns exist on both instances as of today, but nothing can populate them until this ships.

No behaviour change to the nightly ETL: the script is not referenced by `run_all.py` and only runs when invoked by hand.